### PR TITLE
ci(jreleaser): make latest if highest version

### DIFF
--- a/composite/github-release/action.yml
+++ b/composite/github-release/action.yml
@@ -12,17 +12,6 @@ runs:
         ref: main
         path: jreleaser
 
-    - name: Setup - Copy jreleaser.yml
-      shell: bash
-      run: |
-        cp jreleaser/jreleaser.yml .
-
-    - name: Patch jreleaser.yml if MAKE_LATEST
-      if: env.MAKE_LATEST == 'false'
-      shell: bash
-      run: |
-        sed -i "s/makeLatest: 'TRUE'/makeLatest: 'FALSE'/g" jreleaser.yml
-
     - name: Setup - Generate variables for JReleaser
       shell: bash
       run: |
@@ -37,6 +26,30 @@ runs:
           echo "BRANCH=master" >> $GITHUB_ENV
         else
           echo "BRANCH=develop" >> $GITHUB_ENV
+        fi
+
+    - name: Setup - Copy jreleaser.yml
+      shell: bash
+      run: |
+        cp jreleaser/jreleaser.yml .
+
+    - name: Patch jreleaser.yml for major releases
+      shell: bash
+      run: |
+        # Retrieve all existing versions (tags) and add the current version
+        all_versions=$( (git tag -l 'v*' | sed 's/^v//' ; echo "${{ env.VERSION }}" ) | sort -V)
+
+        # Get the highest version
+        highest=$(echo "$all_versions" | tail -n1)
+
+        echo "Current version: ${{ env.VERSION }}"
+        echo "Highest version: $highest"
+
+        if [ "${{ env.VERSION }}" = "$highest" ]; then
+          echo "→ This is the highest version, setting makeLatest=TRUE"
+          sed -i "s/makeLatest: 'FALSE'/makeLatest: 'TRUE'/g" jreleaser.yml
+        else
+          echo "→ Not the highest version, keep makeLatest=FALSE"
         fi
         
     - name: Setup - Set Java

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -91,7 +91,7 @@ release:
             - 'choredeps'
             - 'deps'
           order: 6
-    makeLatest: 'TRUE'
+    makeLatest: 'FALSE'
 files:
   globs:
     - pattern: "**/build/libs/**"


### PR DESCRIPTION
fixes https://github.com/kestra-io/kestra-ee/issues/5208 

In addition, script to pass to set the highest version for all repositories:

```bash
#!/bin/bash

# List all repositories from the kestra-io organization (non-archived)
gh repo list kestra-io --no-archived --limit 10000 --json name | \
  jq -r '.[].name' | \
  sort | \
  while read -r REPO; do
    echo "➡️ Checking releases for kestra-io/$REPO"

    # Get all release tags, strip the leading "v", sort them as semantic versions, and pick the highest one
    HIGHEST=$(gh release list --limit 100 --repo "kestra-io/$REPO" --json tagName \
      | jq -r '.[].tagName' \
      | sed 's/^v//' \
      | sort -V \
      | tail -n1)

    if [ -z "$HIGHEST" ]; then
      echo "   ⚠️  No releases found in $REPO, skipping."
      continue
    fi

    echo "   Highest version found: v$HIGHEST"

    # Mark this release as the latest one on GitHub
    gh release edit "v$HIGHEST" --latest --repo "kestra-io/$REPO"

    echo "   ✅ Updated latest to v$HIGHEST for $REPO"
    echo
done

echo "Done."
```