### PR TITLE
feat: nightly plugins compatibility check against Kestra develop

### DIFF
--- a/.github/workflows/plugins-nightly.yml
+++ b/.github/workflows/plugins-nightly.yml
@@ -32,7 +32,7 @@ jobs:
       - name: List plugin, storage and secret repositories
         id: list
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_PAT || github.token }}
         run: |
           REPOS=$(gh api --paginate "/orgs/kestra-io/repos?per_page=100" \
             -q '.[].name' | grep -E "^(plugin|storage|secret)-" | sort)

--- a/.github/workflows/plugins-nightly.yml
+++ b/.github/workflows/plugins-nightly.yml
@@ -1,6 +1,9 @@
 name: Nightly Plugins Compatibility Check
 
 on:
+  push:
+    branches:
+      - 'kestra-ee/issues/6653'
   schedule:
     - cron: '0 3 * * *' # ~5h Paris time (CEST)
   workflow_dispatch: {}
@@ -29,7 +32,7 @@ jobs:
       - name: List plugin, storage and secret repositories
         id: list
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
         run: |
           REPOS=$(gh api --paginate "/orgs/kestra-io/repos?per_page=100" \
             -q '.[].name' | grep -E "^(plugin|storage|secret)-" | sort)
@@ -54,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kestra-io/${{ matrix.repo }}
-          token: ${{ secrets.GITHUB_PAT }}
+          token: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Checkout actions
         uses: actions/checkout@v4
@@ -81,7 +84,7 @@ jobs:
         id: compile
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
         run: |
           ./gradlew compileJava compileTestJava --parallel 2>&1 | tee /tmp/compile.log
           exit ${PIPESTATUS[0]}
@@ -101,7 +104,7 @@ jobs:
         if: steps.compile.outcome == 'success'
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
         run: |
           if [ -f .github/setup-unit.sh ]; then
             ./.github/setup-unit.sh

--- a/.github/workflows/plugins-nightly.yml
+++ b/.github/workflows/plugins-nightly.yml
@@ -32,7 +32,7 @@ jobs:
       - name: List plugin, storage and secret repositories
         id: list
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_PAT || github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           REPOS=$(gh api --paginate "/orgs/kestra-io/repos?per_page=100" \
             -q '.[].name' | grep -E "^(plugin|storage|secret)-" | sort)

--- a/.github/workflows/plugins-nightly.yml
+++ b/.github/workflows/plugins-nightly.yml
@@ -1,9 +1,6 @@
 name: Nightly Plugins Compatibility Check
 
 on:
-  push:
-    branches:
-      - 'kestra-ee/issues/6653'
   schedule:
     - cron: '0 3 * * *' # ~5h Paris time (CEST)
   workflow_dispatch: {}
@@ -32,10 +29,13 @@ jobs:
       - name: List plugin, storage and secret repositories
         id: list
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_PAT }}
         run: |
           REPOS=$(gh api --paginate "/orgs/kestra-io/repos?per_page=100" \
-            -q '.[].name' | grep -E "^(plugin|storage|secret)-" | sort)
+            -q '.[] | select(.archived == false) | .name' \
+            | grep -E "^(plugin|storage|secret)-" \
+            | grep -v -E "^(plugin-template|plugin-template-maven)$" \
+            | sort)
           echo "Found repos:"
           echo "$REPOS"
           JSON=$(echo "$REPOS" | jq -R -s -c 'split("\n") | map(select(length > 0))')
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kestra-io/${{ matrix.repo }}
-          token: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_PAT }}
 
       - name: Checkout actions
         uses: actions/checkout@v4
@@ -84,7 +84,7 @@ jobs:
         id: compile
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
         run: |
           ./gradlew compileJava compileTestJava --parallel 2>&1 | tee /tmp/compile.log
           exit ${PIPESTATUS[0]}
@@ -93,18 +93,17 @@ jobs:
         if: steps.compile.outcome == 'failure'
         id: errors
         run: |
-          ERRORS=$(grep -E "^e:|error:|FAILED" /tmp/compile.log | head -20)
-          # Escape for GH output (newlines, %, \r)
-          ERRORS="${ERRORS//'%'/'%25'}"
-          ERRORS="${ERRORS//$'\n'/'%0A'}"
-          ERRORS="${ERRORS//$'\r'/'%0D'}"
-          echo "summary=$ERRORS" >> "$GITHUB_OUTPUT"
+          {
+            echo 'summary<<ERRORS_EOF'
+            tail -50 /tmp/compile.log
+            echo 'ERRORS_EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Test
         if: steps.compile.outcome == 'success'
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
         run: |
           if [ -f .github/setup-unit.sh ]; then
             ./.github/setup-unit.sh
@@ -118,7 +117,7 @@ jobs:
           if [ "${{ steps.compile.outcome }}" == "failure" ]; then
             echo "### :x: Compilation failed" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
-            grep -E "^e:|error:|FAILED" /tmp/compile.log | head -30 >> "$GITHUB_STEP_SUMMARY" || true
+            tail -50 /tmp/compile.log >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           elif [ "${{ steps.compile.outcome }}" == "success" ]; then
             echo ":white_check_mark: Compilation succeeded" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/plugins-nightly.yml
+++ b/.github/workflows/plugins-nightly.yml
@@ -1,0 +1,104 @@
+name: Nightly Plugins Compatibility Check
+
+on:
+  schedule:
+    - cron: '0 3 * * *' # ~5h Paris time (CEST)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Job 1: Discover repos and resolve Kestra develop version
+  # ---------------------------------------------------------------------------
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      repos: ${{ steps.list.outputs.repos }}
+      kestra-version: ${{ steps.kestra-version.outputs.version }}
+    steps:
+      - name: Get Kestra version from develop branch
+        id: kestra-version
+        run: |
+          VERSION=$(curl -sS "https://raw.githubusercontent.com/kestra-io/kestra/develop/gradle.properties" \
+            | grep "^version=" | cut -d'=' -f2)
+          echo "Kestra develop version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: List plugin, storage and secret repositories
+        id: list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_PAT }}
+        run: |
+          REPOS=$(gh api --paginate "/orgs/kestra-io/repos?per_page=100" \
+            -q '.[].name' | grep -E "^(plugin|storage|secret)-" | sort)
+          echo "Found repos:"
+          echo "$REPOS"
+          JSON=$(echo "$REPOS" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "repos=$JSON" >> "$GITHUB_OUTPUT"
+
+  # ---------------------------------------------------------------------------
+  # Job 2: Build each repo with the latest Kestra develop version
+  # ---------------------------------------------------------------------------
+  build:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo: ${{ fromJson(needs.setup.outputs.repos) }}
+    name: ${{ matrix.repo }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: kestra-io/${{ matrix.repo }}
+          token: ${{ secrets.GITHUB_PAT }}
+
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        with:
+          repository: kestra-io/actions
+          path: .github/actions
+
+      - name: Setup build
+        uses: ./.github/actions/composite/setup-build
+        with:
+          java-enabled: true
+
+      - name: Override kestraVersion in gradle.properties
+        run: |
+          if grep -q "^kestraVersion=" gradle.properties; then
+            ORIGINAL=$(grep "^kestraVersion=" gradle.properties | cut -d'=' -f2)
+            echo "Overriding kestraVersion: $ORIGINAL -> ${{ needs.setup.outputs.kestra-version }}"
+            sed -i "s/^kestraVersion=.*/kestraVersion=${{ needs.setup.outputs.kestra-version }}/" gradle.properties
+          else
+            echo "No kestraVersion found in gradle.properties, skipping."
+          fi
+
+      - name: Compile
+        id: compile
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+        run: ./gradlew compileJava compileTestJava --parallel
+
+      - name: Test
+        if: steps.compile.outcome == 'success'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+        run: |
+          if [ -f .github/setup-unit.sh ]; then
+            ./.github/setup-unit.sh
+          fi
+          ./gradlew check --parallel
+
+      - name: Slack alert on compilation failure
+        if: steps.compile.outcome == 'failure'
+        uses: ./.github/actions/composite/slack-status
+        with:
+          channel: "C09FE0QCN2E" # #_int_alert-plugins-build
+          status: "failure"
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/plugins-nightly.yml
+++ b/.github/workflows/plugins-nightly.yml
@@ -1,6 +1,9 @@
 name: Nightly Plugins Compatibility Check
 
 on:
+  push:
+    branches:
+      - 'kestra-ee/issues/6653'
   schedule:
     - cron: '0 3 * * *' # ~5h Paris time (CEST)
   workflow_dispatch: {}

--- a/.github/workflows/plugins-nightly.yml
+++ b/.github/workflows/plugins-nightly.yml
@@ -1,9 +1,6 @@
 name: Nightly Plugins Compatibility Check
 
 on:
-  push:
-    branches:
-      - 'kestra-ee/issues/6653'
   schedule:
     - cron: '0 3 * * *' # ~5h Paris time (CEST)
   workflow_dispatch: {}
@@ -32,7 +29,7 @@ jobs:
       - name: List plugin, storage and secret repositories
         id: list
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_PAT }}
         run: |
           REPOS=$(gh api --paginate "/orgs/kestra-io/repos?per_page=100" \
             -q '.[].name' | grep -E "^(plugin|storage|secret)-" | sort)
@@ -57,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kestra-io/${{ matrix.repo }}
-          token: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_PAT }}
 
       - name: Checkout actions
         uses: actions/checkout@v4
@@ -84,19 +81,45 @@ jobs:
         id: compile
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
-        run: ./gradlew compileJava compileTestJava --parallel
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+        run: |
+          ./gradlew compileJava compileTestJava --parallel 2>&1 | tee /tmp/compile.log
+          exit ${PIPESTATUS[0]}
+
+      - name: Extract compilation errors
+        if: steps.compile.outcome == 'failure'
+        id: errors
+        run: |
+          ERRORS=$(grep -E "^e:|error:|FAILED" /tmp/compile.log | head -20)
+          # Escape for GH output (newlines, %, \r)
+          ERRORS="${ERRORS//'%'/'%25'}"
+          ERRORS="${ERRORS//$'\n'/'%0A'}"
+          ERRORS="${ERRORS//$'\r'/'%0D'}"
+          echo "summary=$ERRORS" >> "$GITHUB_OUTPUT"
 
       - name: Test
         if: steps.compile.outcome == 'success'
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
         run: |
           if [ -f .github/setup-unit.sh ]; then
             ./.github/setup-unit.sh
           fi
           ./gradlew check --parallel
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## ${{ matrix.repo }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.compile.outcome }}" == "failure" ]; then
+            echo "### :x: Compilation failed" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            grep -E "^e:|error:|FAILED" /tmp/compile.log | head -30 >> "$GITHUB_STEP_SUMMARY" || true
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.compile.outcome }}" == "success" ]; then
+            echo ":white_check_mark: Compilation succeeded" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Slack alert on compilation failure
         if: steps.compile.outcome == 'failure'
@@ -104,4 +127,5 @@ jobs:
         with:
           channel: "C09FE0QCN2E" # #_int_alert-plugins-build
           status: "failure"
+          message: "`${{ matrix.repo }}` compilation failed\n```${{ steps.errors.outputs.summary }}```"
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/plugins-nightly.yml
+++ b/.github/workflows/plugins-nightly.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kestra-io/${{ matrix.repo }}
-          token: ${{ secrets.GITHUB_PAT }}
+          token: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Checkout actions
         uses: actions/checkout@v4
@@ -84,14 +84,14 @@ jobs:
         id: compile
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
         run: ./gradlew compileJava compileTestJava --parallel
 
       - name: Test
         if: steps.compile.outcome == 'success'
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
         run: |
           if [ -f .github/setup-unit.sh ]; then
             ./.github/setup-unit.sh

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -213,7 +213,7 @@ jobs:
         if: always() && env.SLACK_WEBHOOK_URL != '' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && job.status == 'failure'
         uses: kestra-io/actions/composite/slack-status@main
         with:
-          channel: "C09FE0QCN2E"
+          channel: "C09FE0QCN2E" # #_int_alert-plugins-build
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       # Allure report permissions

--- a/composite/slack-status/action.yml
+++ b/composite/slack-status/action.yml
@@ -11,11 +11,17 @@ inputs:
     description: 'The slack incoming webhook url'
     required: true
 
+  status:
+    description: 'Override job status (defaults to job.status if not set)'
+    required: false
+
 runs:
   using: composite
   steps:
   - name: Slack - Post
     uses: slackapi/slack-github-action@v2.1.1
+    env:
+      EFFECTIVE_STATUS: ${{ inputs.status || job.status }}
     with:
       errors: true
       webhook: ${{ inputs.webhook-url }}
@@ -24,9 +30,9 @@ runs:
         username: GitHub Actions
         icon_emoji: ':github-actions:'
         channel: "${{ inputs.channel }}"
-        text: "<${{ github.event.repository.html_url }}|[${{ github.event.repository.full_name }}]> *${{ github.workflow }}* ended with status `${{ job.status }}`" 
+        text: "<${{ github.event.repository.html_url }}|[${{ github.event.repository.full_name }}]> *${{ github.workflow }}* ended with status `${{ env.EFFECTIVE_STATUS }}`"
         attachments:
-          - color: "${{ job.status == 'success' && '#388E3C' || '#D32F2F' }}"
+          - color: "${{ env.EFFECTIVE_STATUS == 'success' && '#388E3C' || '#D32F2F' }}"
             blocks:
               - type: actions
                 elements:

--- a/composite/slack-status/action.yml
+++ b/composite/slack-status/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Override job status (defaults to job.status if not set)'
     required: false
 
+  message:
+    description: 'Optional extra text appended to the Slack message'
+    required: false
+
 runs:
   using: composite
   steps:
@@ -30,7 +34,7 @@ runs:
         username: GitHub Actions
         icon_emoji: ':github-actions:'
         channel: "${{ inputs.channel }}"
-        text: "<${{ github.event.repository.html_url }}|[${{ github.event.repository.full_name }}]> *${{ github.workflow }}* ended with status `${{ env.EFFECTIVE_STATUS }}`"
+        text: "<${{ github.event.repository.html_url }}|[${{ github.event.repository.full_name }}]> *${{ github.workflow }}* ended with status `${{ env.EFFECTIVE_STATUS }}`${{ inputs.message && format(' — {0}', inputs.message) || '' }}"
         attachments:
           - color: "${{ env.EFFECTIVE_STATUS == 'success' && '#388E3C' || '#D32F2F' }}"
             blocks:


### PR DESCRIPTION
## Summary

- Adds a **nightly scheduled workflow** (`0 3 * * *` UTC, ~5h Paris) that:
  1. Fetches the latest Kestra version from the `develop` branch (`gradle.properties`)
  2. Lists all `plugin-*`, `storage-*` and `secret-*` repos in the org
  3. For each repo: overrides `kestraVersion`, compiles, and runs tests
  4. **Alerts `#_int_alert-plugins-build` only on compilation failures** (test failures are silent)
- Adds a `status` input to the `slack-status` composite action to allow overriding `job.status` (backwards-compatible, defaults to `job.status` when not set). Input added because the compile step uses `continue-on-error: true` to allow tests to run independently. This means `job.status` remains success even when compilation fails so slack-status would send a green "success" message. The status input lets us explicitly pass failure to override job.status.
- Adds channel name comment next to Slack channel IDs for readability

## Test plan

- [ ] Trigger manually via `workflow_dispatch` and verify the setup job discovers repos correctly
- [ ] Verify compilation step runs with overridden `kestraVersion`
- [ ] Verify Slack alert fires only on compilation failure (not test failure)
- [ ] Verify existing `plugins.yml` Slack notifications still work (no regression on `slack-status`)

fixes https://github.com/kestra-io/kestra-ee/issues/6653 