### PR TITLE
fix(kestra-ee-checkout): use OSS PR merge ref when a matching PR exists

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -60,6 +60,13 @@ jobs:
           fetch-tags: true
           submodules: true
 
+      - name: Setup - Patch Gradle JVM args
+        shell: bash
+        run: |
+          if ! grep -q "^org.gradle.jvmargs=" gradle.properties; then
+            echo "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g" >> gradle.properties
+          fi
+
       # Override kestraVersion in gradle.properties if a specific version is requested
       - name: Setup - Override Kestra version
         if: ${{ inputs.kestra-version != '' }}

--- a/composite/kestra-ee/kestra-ee-checkout/action.yml
+++ b/composite/kestra-ee/kestra-ee-checkout/action.yml
@@ -20,12 +20,12 @@ runs:
               # Check if that branch is the head of an open OSS PR — if so use the
               # merge ref so both EE and OSS are tested at their simulated-merge state.
               OSS_PR_REF=$(git ls-remote https://github.com/kestra-io/kestra.git 'refs/pull/*/head' \
-                | grep "^$BRANCH_SHA" | head -1 | awk '{print $2}' | sort -t'/' -k3 -n -r | head -1)
+                | grep "^$BRANCH_SHA" | sort -t'/' -k3 -n -r | head -1 | awk '{print $2}')
 
               if [[ ! -z "$OSS_PR_REF" ]]; then
                 OSS_PR_NUMBER=$(echo "$OSS_PR_REF" | sed 's|refs/pull/||;s|/head||')
                 MERGE_EXISTS=$(git ls-remote https://github.com/kestra-io/kestra.git \
-    "refs/pull/$OSS_PR_NUMBER/merge")
+                  "refs/pull/$OSS_PR_NUMBER/merge")
                 if [[ ! -z "$MERGE_EXISTS" ]]; then
                   echo "ossBranch=refs/pull/$OSS_PR_NUMBER/merge" >> "$GITHUB_OUTPUT"
                 else

--- a/composite/kestra-ee/kestra-ee-checkout/action.yml
+++ b/composite/kestra-ee/kestra-ee-checkout/action.yml
@@ -20,7 +20,7 @@ runs:
               # Check if that branch is the head of an open OSS PR — if so use the
               # merge ref so both EE and OSS are tested at their simulated-merge state.
               OSS_PR_REF=$(git ls-remote https://github.com/kestra-io/kestra.git 'refs/pull/*/head' \
-                | grep "^$BRANCH_SHA" | head -1 | awk '{print $2}')
+                | grep "^$BRANCH_SHA" | head -1 | awk '{print $2}' | sort -t'/' -k3 -n -r | head -1)
 
               if [[ ! -z "$OSS_PR_REF" ]]; then
                 OSS_PR_NUMBER=$(echo "$OSS_PR_REF" | sed 's|refs/pull/||;s|/head||')

--- a/composite/kestra-ee/kestra-ee-checkout/action.yml
+++ b/composite/kestra-ee/kestra-ee-checkout/action.yml
@@ -13,10 +13,23 @@ runs:
         if ${{ github.event_name == 'pull_request' }}; then
       
             # try to find if there is an associated OSS branch
-            ASSOCIATED_OSS_BRANCH_FOUND=$(git ls-remote https://github.com/kestra-io/kestra.git ${{ github.head_ref }})
-            if [[ ! -z $ASSOCIATED_OSS_BRANCH_FOUND ]]; then
+            BRANCH_SHA=$(git ls-remote https://github.com/kestra-io/kestra.git refs/heads/${{ github.head_ref }} | cut -f1)
+            if [[ ! -z "$BRANCH_SHA" ]]; then
               echo "associated branch found ${{ github.head_ref }}"
-              echo "ossBranch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+
+              # Check if that branch is the head of an open OSS PR — if so use the
+              # merge ref so both EE and OSS are tested at their simulated-merge state.
+              OSS_PR_REF=$(git ls-remote https://github.com/kestra-io/kestra.git 'refs/pull/*/head' \
+                | grep "^$BRANCH_SHA" | head -1 | awk '{print $2}')
+
+              if [[ ! -z "$OSS_PR_REF" ]]; then
+                OSS_PR_NUMBER=$(echo "$OSS_PR_REF" | sed 's|refs/pull/||;s|/head||')
+                echo "found OSS PR #$OSS_PR_NUMBER for branch ${{ github.head_ref }}, using merge ref"
+                echo "ossBranch=refs/pull/$OSS_PR_NUMBER/merge" >> "$GITHUB_OUTPUT"
+              else
+                echo "no open OSS PR found for branch ${{ github.head_ref }}, using branch directly"
+                echo "ossBranch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+              fi
               exit 0
             fi
         

--- a/composite/kestra-ee/kestra-ee-checkout/action.yml
+++ b/composite/kestra-ee/kestra-ee-checkout/action.yml
@@ -24,8 +24,14 @@ runs:
 
               if [[ ! -z "$OSS_PR_REF" ]]; then
                 OSS_PR_NUMBER=$(echo "$OSS_PR_REF" | sed 's|refs/pull/||;s|/head||')
-                echo "found OSS PR #$OSS_PR_NUMBER for branch ${{ github.head_ref }}, using merge ref"
-                echo "ossBranch=refs/pull/$OSS_PR_NUMBER/merge" >> "$GITHUB_OUTPUT"
+                MERGE_EXISTS=$(git ls-remote https://github.com/kestra-io/kestra.git \
+    "refs/pull/$OSS_PR_NUMBER/merge")
+                if [[ ! -z "$MERGE_EXISTS" ]]; then
+                  echo "ossBranch=refs/pull/$OSS_PR_NUMBER/merge" >> "$GITHUB_OUTPUT"
+                else
+                  echo "OSS PR #$OSS_PR_NUMBER has conflicts, falling back to branch tip"
+                  echo "ossBranch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+                fi
               else
                 echo "no open OSS PR found for branch ${{ github.head_ref }}, using branch directly"
                 echo "ossBranch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
✨ Description
When a kestra-ee PR has a corresponding open PR in the kestra OSS repo (same branch name), the kestra-ee-checkout action was checking out the raw branch tip for OSS while checking out the simulated-merge ref (refs/pull/PRNUM/merge) for EE. This meant the two repos were being tested at different points in their history.

The fix uses git ls-remote to resolve the OSS branch SHA, then scans refs/pull/*/head to find a matching PR. If one is found, it checks out refs/pull/PRNUM/merge instead of the branch directly — keeping OSS and EE at equivalent simulated-merge states. No API calls or extra tooling required.