### PR TITLE
build: add explicit npm build steps after node-gradle removal

### DIFF
--- a/.github/workflows/kestra-ee-build-artifacts.yml
+++ b/.github/workflows/kestra-ee-build-artifacts.yml
@@ -51,11 +51,14 @@ jobs:
           node-enabled: 'true'
           java-version: ${{ inputs.java-version }}
 
-      - name: build OSS UI required for EE UI build
+      - name: Build frontend
         shell: bash
         run: |
           cd kestra/ui
           npm ci
+          cd ../../kestra-ee/ui-ee
+          npm install
+          npm run build
 
       # Shadow Jar
       - name: Gradle - Build jars

--- a/.github/workflows/kestra-ee-build-artifacts.yml
+++ b/.github/workflows/kestra-ee-build-artifacts.yml
@@ -62,11 +62,14 @@ jobs:
           gradle-tracing-enabled: 'true'
           service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"
 
-      - name: build OSS UI required for EE UI build
+      - name: Build frontend
         shell: bash
         run: |
           cd kestra/ui
           npm ci
+          cd ../../kestra-ee/ui-ee
+          npm install
+          npm run build
 
       # Detect whether this version ships the cloud-ee module (2.0+ / develop).
       # Older versions (1.3 and earlier) don't have it, so the cloud steps are skipped.

--- a/.github/workflows/kestra-ee-publish-maven.yml
+++ b/.github/workflows/kestra-ee-publish-maven.yml
@@ -37,6 +37,7 @@ jobs:
         uses: kestra-io/actions/composite/setup-build@main
         with:
           java-enabled: 'true'
+          node-enabled: 'true'
           java-version: ${{ inputs.java-version }}
 
       # Google Auth
@@ -45,6 +46,15 @@ jobs:
         uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SERVICE_ACCOUNT }}'
+
+      - name: Build frontend
+        shell: bash
+        run: |
+          cd kestra/ui
+          npm ci
+          cd ../../kestra-ee/ui-ee
+          npm install
+          npm run build
 
       # Publish
       - name: Publish - Release package with Gradle

--- a/.github/workflows/kestra-ee-publish-maven.yml
+++ b/.github/workflows/kestra-ee-publish-maven.yml
@@ -38,6 +38,7 @@ jobs:
         uses: kestra-io/actions/composite/setup-build@main
         with:
           java-enabled: 'true'
+          node-enabled: 'true'
           java-version: ${{ inputs.java-version }}
 
       - name: Setup - OpenTelemetry
@@ -57,6 +58,15 @@ jobs:
         uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_SERVICE_ACCOUNT }}'
+
+      - name: Build frontend
+        shell: bash
+        run: |
+          cd kestra/ui
+          npm ci
+          cd ../../kestra-ee/ui-ee
+          npm install
+          npm run build
 
       # Publish
       - name: Publish - Release package with Gradle

--- a/.github/workflows/kestra-oss-build-artifacts.yml
+++ b/.github/workflows/kestra-oss-build-artifacts.yml
@@ -26,10 +26,12 @@ jobs:
           fetch-depth: 0
 
       # Npm
-      - name: Setup - Npm install
+      - name: Setup - Npm install & build
         shell: bash
         working-directory: ui
-        run: npm ci
+        run: |
+          npm ci
+          npm run build
 
       # Setup build
       - uses: kestra-io/actions/composite/setup-build@main

--- a/.github/workflows/kestra-oss-build-artifacts.yml
+++ b/.github/workflows/kestra-oss-build-artifacts.yml
@@ -48,10 +48,12 @@ jobs:
           service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"
 
       # Npm
-      - name: Setup - Npm install
+      - name: Setup - Npm install & build
         shell: bash
         working-directory: ui
-        run: npm ci
+        run: |
+          npm ci
+          npm run build
 
       # Build
       - name: Gradle - Build

--- a/.github/workflows/kestra-oss-publish-maven.yml
+++ b/.github/workflows/kestra-oss-publish-maven.yml
@@ -44,6 +44,13 @@ jobs:
           node-enabled: true
           java-version: ${{ inputs.java-version }}
 
+      - name: Build frontend
+        shell: bash
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build
+
       # Publish
       - name: Publish - Release package to Maven Central
         shell: bash

--- a/.github/workflows/kestra-oss-publish-maven.yml
+++ b/.github/workflows/kestra-oss-publish-maven.yml
@@ -58,6 +58,13 @@ jobs:
           gradle-tracing-enabled: 'true'
           service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"
 
+      - name: Build frontend
+        shell: bash
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build
+
       # Publish
       - name: Publish - Release package to Maven Central
         shell: bash


### PR DESCRIPTION
After removing the node-gradle Gradle plugin from kestra and kestra-ee, CI workflows must explicitly run npm install/build before Gradle tasks that produce JARs with bundled UI assets.

Adds frontend build steps to build-artifacts and Maven publish workflows for both OSS and EE.

Companion PRs: kestra-io/kestra#15689, [kestra-io/kestra-ee#7535](https://github.com/kestra-io/kestra-ee/pull/7535)