### PR TITLE
feat(slack-status): mention committer on failure via users-map input

### DIFF
--- a/composite/slack-status/action.yml
+++ b/composite/slack-status/action.yml
@@ -21,6 +21,16 @@ inputs:
     required: false
     default: ''
 
+  committer-login:
+    description: 'GitHub login to mention. When unset, the action falls back to head_commit.author.username then github.actor. Set this when the responsible committer cannot be derived from the event (e.g. repository_dispatch carrying a foreign commit sha).'
+    required: false
+    default: ''
+
+  extra-text:
+    description: 'Optional extra sentence appended to the Slack message text. Used by callers to add context such as why this failure was triggered.'
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -28,7 +38,7 @@ runs:
     id: mention
     shell: bash
     env:
-      LOGIN: ${{ github.event.head_commit.author.username || github.actor }}
+      LOGIN: ${{ inputs.committer-login || github.event.head_commit.author.username || github.actor }}
       USERS_MAP: ${{ inputs.users-map }}
     run: |
       mention=""
@@ -56,7 +66,7 @@ runs:
         username: GitHub Actions
         icon_emoji: ':github-actions:'
         channel: "${{ inputs.channel }}"
-        text: "${{ steps.mention.outputs.mention && format('{0} ', steps.mention.outputs.mention) || '' }}<${{ github.event.repository.html_url }}|[${{ github.event.repository.full_name }}]> *${{ github.workflow }}${{ inputs.suffix && format(' ({0})', inputs.suffix) || '' }}* ended with status `${{ job.status }}`"
+        text: "${{ steps.mention.outputs.mention && format('{0} ', steps.mention.outputs.mention) || '' }}<${{ github.event.repository.html_url }}|[${{ github.event.repository.full_name }}]> *${{ github.workflow }}${{ inputs.suffix && format(' ({0})', inputs.suffix) || '' }}* ended with status `${{ job.status }}`${{ inputs.extra-text && format(' — {0}', inputs.extra-text) || '' }}"
         attachments:
           - color: "${{ job.status == 'success' && '#388E3C' || '#D32F2F' }}"
             blocks:

--- a/composite/slack-status/action.yml
+++ b/composite/slack-status/action.yml
@@ -16,9 +16,36 @@ inputs:
     required: false
     default: ''
 
+  users-map:
+    description: 'JSON object mapping GitHub login to Slack member ID. When provided, the responsible committer is @-mentioned in the Slack message so the build failure is not silently ignored. Typically passed as `${{ vars.GITHUB_TO_SLACK_MAP }}` from the kestra-io org variable managed by terraform in kestra-io/infra.'
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
+  - name: Resolve Slack mention
+    id: mention
+    shell: bash
+    env:
+      LOGIN: ${{ github.event.head_commit.author.username || github.actor }}
+      USERS_MAP: ${{ inputs.users-map }}
+    run: |
+      mention=""
+      if [ -z "${LOGIN}" ]; then
+        echo "::warning::Could not determine GitHub login (head_commit.author.username and github.actor both empty); no Slack mention added."
+      elif [ -z "${USERS_MAP}" ]; then
+        echo "::notice::users-map input not provided to slack-status; no Slack mention added."
+      else
+        slack_id="$(printf '%s' "${USERS_MAP}" | jq -r --arg l "${LOGIN}" '.[$l] // ""')"
+        if [ -n "${slack_id}" ]; then
+          mention="<@${slack_id}>"
+        else
+          echo "::warning::No Slack mapping for GitHub user '${LOGIN}'. Add it via terraform/github/slack_users.tf in kestra-io/infra so future failures ping you."
+        fi
+      fi
+      echo "mention=${mention}" >> "${GITHUB_OUTPUT}"
+
   - name: Slack - Post
     uses: slackapi/slack-github-action@v2.1.1
     with:
@@ -29,7 +56,7 @@ runs:
         username: GitHub Actions
         icon_emoji: ':github-actions:'
         channel: "${{ inputs.channel }}"
-        text: "<${{ github.event.repository.html_url }}|[${{ github.event.repository.full_name }}]> *${{ github.workflow }}${{ inputs.suffix && format(' ({0})', inputs.suffix) || '' }}* ended with status `${{ job.status }}`" 
+        text: "${{ steps.mention.outputs.mention && format('{0} ', steps.mention.outputs.mention) || '' }}<${{ github.event.repository.html_url }}|[${{ github.event.repository.full_name }}]> *${{ github.workflow }}${{ inputs.suffix && format(' ({0})', inputs.suffix) || '' }}* ended with status `${{ job.status }}`"
         attachments:
           - color: "${{ job.status == 'success' && '#388E3C' || '#D32F2F' }}"
             blocks:


### PR DESCRIPTION
- new optional \`users-map\` input on the \`slack-status\` composite action: JSON object mapping GitHub login -> Slack member ID
- resolve the responsible login from \`head_commit.author.username\`, falling back to \`github.actor\`
- prepend \`<@SLACK_ID>\` to the top-level \`text:\` of the Slack payload so the user actually gets a push notification (mentions inside \`attachments\` blocks do not notify)
- when the login is missing from the map (or the input is not provided), the message is posted unchanged and a \`::warning::\` is emitted so the unmapped user notices and adds themselves
- the mapping itself is kept out of this public repository: it is passed at runtime by callers from the \`GITHUB_TO_SLACK_MAP\` org variable managed by terraform in \`kestra-io/infra\`
- companion PRs: \`kestra-io/infra\` (variable), \`kestra-io/kestra\` and \`kestra-io/kestra-ee\` (forward the variable to this action)