### PR TITLE
feat: move Slack release notification from GitHub release to Docker publish

### DIFF
--- a/.github/workflows/kestra-ee-publish-docker.yml
+++ b/.github/workflows/kestra-ee-publish-docker.yml
@@ -13,6 +13,8 @@ on:
       DOCKERHUB_TOKEN:
         description: "The DockerHub token"
         required: true
+      SLACK_RELEASES_WEBHOOK_URL:
+        required: false
     inputs:
       retag-latest:
         description: 'Retag latest Docker images'
@@ -250,3 +252,17 @@ jobs:
 
           regctl image copy ${{ env.GCP_IMAGE_PATH }}:${{ steps.vars.outputs.tag }} ${{ env.GCP_IMAGE_PATH }}:latest-lts${{ matrix.image.tag }}
           regctl image copy ${{ env.GITHUB_IMAGE_PATH }}:${{ steps.vars.outputs.tag }} ${{ env.GITHUB_IMAGE_PATH }}:latest-lts${{ matrix.image.tag }}
+
+  end:
+    runs-on: ubuntu-latest
+    needs:
+      - docker
+    if: always()
+    env:
+      SLACK_RELEASES_WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
+    steps:
+      - name: Slack notification on success
+        if: ${{ !failure() && !cancelled() && !inputs.dry-run && env.SLACK_RELEASES_WEBHOOK_URL != 0 }}
+        uses: kestra-io/actions/composite/slack-status@main
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}

--- a/.github/workflows/kestra-ee-publish-github.yml
+++ b/.github/workflows/kestra-ee-publish-github.yml
@@ -57,6 +57,8 @@ jobs:
       - name: Create GitHub release
         uses: kestra-io/actions/composite/github-release@main
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          announce-slack: 'false'
         env:
           MAKE_LATEST: ${{ steps.is_latest.outputs.latest }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -11,6 +11,8 @@ on:
         required: true
       SLACK_WEBHOOK_URL:
         required: true
+      SLACK_RELEASES_WEBHOOK_URL:
+        required: false
       GH_PERSONAL_TOKEN:
         description: "GH token needed for triggering helm chart PR."
         required: true
@@ -233,9 +235,15 @@ jobs:
     if: always()
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_RELEASES_WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
     steps:
-      - name: Slack notification
+      - name: Slack notification on failure
         if: ${{ failure() && env.SLACK_WEBHOOK_URL != 0 }}
         uses: kestra-io/actions/composite/slack-status@main
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Slack notification on success
+        if: ${{ !failure() && !cancelled() && !inputs.dry-run && env.SLACK_RELEASES_WEBHOOK_URL != 0 }}
+        uses: kestra-io/actions/composite/slack-status@main
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}

--- a/.github/workflows/kestra-oss-publish-github.yml
+++ b/.github/workflows/kestra-oss-publish-github.yml
@@ -50,6 +50,8 @@ jobs:
       - name: Create GitHub release
         uses: kestra-io/actions/composite/github-release@main
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        with:
+          announce-slack: 'false'
         env:
           MAKE_LATEST: ${{ steps.is_latest.outputs.latest }}
           GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}

--- a/composite/github-release/action.yml
+++ b/composite/github-release/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Java version"
     default: '21'
     required: true
+  announce-slack:
+    description: "Whether to announce the release on Slack via JReleaser"
+    default: 'true'
+    required: false
 
 runs:
   using: composite
@@ -69,7 +73,7 @@ runs:
         JRELEASER_BRANCH: ${{ env.BRANCH}}
         JRELEASER_GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         JRELEASER_PROJECT_VERSION: ${{ env.VERSION }}
-        JRELEASER_ANNOUNCE_SLACK_WEBHOOK: ${{ env.SLACK_RELEASES_WEBHOOK_URL }}
+        JRELEASER_ANNOUNCE_SLACK_WEBHOOK: ${{ inputs.announce-slack == 'true' && env.SLACK_RELEASES_WEBHOOK_URL || '' }}
 
     - name: JReleaser - Output properties & logs
       if: always()


### PR DESCRIPTION
## Summary

- Add `announce-slack` input (default `true`) to `composite/github-release/action.yml` so other projects continue to get the JReleaser Slack announcement unchanged
- Set `announce-slack: false` in `kestra-oss-publish-github.yml` and `kestra-ee-publish-github.yml` to suppress the early notification for kestra/kestra-ee
- Add `SLACK_RELEASES_WEBHOOK_URL` secret to both docker publish reusable workflows
- Add a success step in the OSS docker publish `end` job posting to `SLACK_RELEASES_WEBHOOK_URL` after images are pushed (dry-run skipped)
- Add a new `end` job to the EE docker publish workflow with the same success notification

Companion PRs: kestra-io/kestra and kestra-io/kestra-ee each add `SLACK_RELEASES_WEBHOOK_URL` to their `release-docker.yml` secrets passthrough.

## Test plan
- [ ] Trigger a dry-run of `release-docker.yml` — no Slack message expected
- [ ] Trigger a real docker publish — Slack message fires in #releases after images are pushed
- [ ] Trigger `pre-release.yml` — no Slack message from the GitHub Release step
- [ ] Verify other projects using `github-release` composite still get Slack announcements (default `announce-slack: true`)