### PR TITLE
fix(pr-docker): derive base image tag from PR target branch

### DIFF
--- a/.github/workflows/kestra-ee-pullrequest-publish-docker.yml
+++ b/.github/workflows/kestra-ee-pullrequest-publish-docker.yml
@@ -63,6 +63,19 @@ jobs:
         run: |
           cp build/executable/* kestra-ee/docker/app/kestra && chmod +x kestra-ee/docker/app/kestra
 
+      - name: Determine base image tag
+        id: base
+        shell: bash
+        run: |
+          if [[ "${{ github.base_ref }}" == "develop" ]]; then
+            echo "tag=develop" >> "$GITHUB_OUTPUT"
+          else
+            ref="${{ github.base_ref }}"
+            ref="${ref#releases/}"
+            ref="${ref%.x}"
+            echo "tag=${ref}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Docker - Build and push
         id: docker-build-push
         uses: docker/build-push-action@v6
@@ -72,7 +85,7 @@ jobs:
           push: true
           tags: ${{ env.GITHUB_IMAGE_PATH }}:${{ github.event.pull_request.number }}
           build-args: |
-            KESTRA_DOCKER_BASE_VERSION: ${{ github.base_ref }})
+            KESTRA_DOCKER_BASE_VERSION=${{ steps.base.outputs.tag }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/kestra-oss-pullrequest-publish-docker.yml
+++ b/.github/workflows/kestra-oss-pullrequest-publish-docker.yml
@@ -54,6 +54,19 @@ jobs:
         run: |
           cp build/executable/* docker/app/kestra && chmod +x docker/app/kestra
 
+      - name: Determine base image tag
+        id: base
+        shell: bash
+        run: |
+          if [[ "${{ github.base_ref }}" == "develop" ]]; then
+            echo "tag=develop" >> "$GITHUB_OUTPUT"
+          else
+            ref="${{ github.base_ref }}"
+            ref="${ref#releases/}"
+            ref="${ref%.x}"
+            echo "tag=${ref}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Docker - Build image
         uses: docker/build-push-action@v6
         with:
@@ -61,6 +74,8 @@ jobs:
           file: ./Dockerfile.pr
           push: true
           tags: ${{ env.GITHUB_IMAGE_PATH }}:${{ github.event.pull_request.number }}
+          build-args: |
+            KESTRA_DOCKER_BASE_VERSION=${{ steps.base.outputs.tag }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Maps `releases/vX.Y.x` -> `vX.Y` and keeps `develop` as-is so PR images are built against a base matching the target branch. Also corrects the build-args syntax (`=` instead of `:`) on the EE workflow and adds the missing KESTRA_DOCKER_BASE_VERSION build-arg to the OSS workflow.