### PR TITLE
build: add CodeQL analysis job to shared plugin workflow

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -44,6 +44,7 @@ permissions:
   actions: read
   pull-requests: write
   packages: read
+  security-events: write
 
 env:
   COMPATIBILITY_JAVA_VERSION: '25'
@@ -270,3 +271,32 @@ jobs:
         if: ${{ (startsWith(github.ref, 'releases/v') || startsWith(github.ref, 'refs/tags/v')) && startsWith(github.repository, 'kestra-io/')  && inputs.skip-indexing == false }}
         with:
           webhookUrl: "${{ secrets.KESTRA_WEBHOOK_URL_PLUGIN_RELEASE_INDEX }}"
+
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: java
+
+      - name: Setup - Build
+        uses: kestra-io/actions/composite/setup-build@main
+        with:
+          java-enabled: true
+          java-version: ${{ inputs.java-version }}
+          java-enable-develocity-injection: false
+
+      - name: Build with Gradle
+        run: ./gradlew testClasses --parallel
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: java

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -272,9 +272,28 @@ jobs:
         with:
           webhookUrl: "${{ secrets.KESTRA_WEBHOOK_URL_PLUGIN_RELEASE_INDEX }}"
 
-  codeql:
-    name: CodeQL
+  codeql-detect:
+    name: CodeQL - Detect languages
     runs-on: ubuntu-latest
+    outputs:
+      has-ui: ${{ steps.check.outputs.has-ui }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for UI folder
+        id: check
+        run: |
+          if [ -f ui/package.json ]; then
+            echo "has-ui=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-ui=false" >> $GITHUB_OUTPUT
+          fi
+
+  codeql-java:
+    name: CodeQL (Java)
+    runs-on: ubuntu-latest
+    needs: codeql-detect
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -300,3 +319,33 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: java
+
+  codeql-javascript:
+    name: CodeQL (JavaScript)
+    runs-on: ubuntu-latest
+    needs: codeql-detect
+    if: ${{ needs.codeql-detect.outputs.has-ui == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript
+
+      - name: Setup - Build
+        uses: kestra-io/actions/composite/setup-build@main
+        with:
+          java-enabled: false
+          node-enabled: true
+          java-version: ${{ inputs.java-version }}
+          java-enable-develocity-injection: false
+
+      - name: Install UI dependencies
+        run: npm install --prefix ui
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: javascript


### PR DESCRIPTION
## Summary

- Adds a `codeql` job to the shared `plugins.yml` reusable workflow
- Scans Java only (plugins are Java-only projects — no frontend)
- Adds the required `security-events: write` permission
- All plugin repos calling this workflow get CodeQL scanning automatically, with no changes needed on their side

## Why

Several plugin repos were hitting a CodeQL fatal error from GitHub's org-level default code scanning:
> CodeQL detected code written in JavaScript/TypeScript but could not process any of it.

Root cause: the default scanner was auto-detecting JS/TS files (e.g. from Gradle wrapper scripts or bundled tooling) and failing because no build setup was present for those languages. By adding an explicit Java-only CodeQL job here, the org-level default setup is overridden consistently across all plugins.