### PR TITLE
fix(ci): use client-id instead of deprecated app-id in create-github-app-token

### DIFF
--- a/.github/workflows/kestra-ee-publish-github.yml
+++ b/.github/workflows/kestra-ee-publish-github.yml
@@ -3,8 +3,11 @@ name: Github - Release
 on:
   workflow_call:
     secrets:
-      GH_PERSONAL_TOKEN:
-        description: "The Github personal token."
+      GH_BOT_CLIENT_ID:
+        description: "GitHub App Client ID."
+        required: true
+      GH_BOT_PRIVATE_KEY:
+        description: "GitHub App private key."
         required: true
       SLACK_RELEASES_WEBHOOK_URL:
         description: "The Slack webhook URL."
@@ -23,6 +26,15 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }},docs
 
       # Download Exec
       # Must be done after checkout actions
@@ -51,7 +63,8 @@ jobs:
         uses: kestra-io/actions/composite/publish-api-reference@main
         if: ${{ steps.is_latest.outputs.latest == 'true' }}
         with:
-          gh_personal_token: ${{ secrets.GH_PERSONAL_TOKEN }}
+          gh-app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
 
       # GitHub Release
       - name: Create GitHub release
@@ -68,5 +81,5 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: kestra-io/actions/composite/github-release-note-merge@main
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TAG: ${{ github.ref_name }}

--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -13,8 +13,11 @@ on:
         required: true
       SLACK_RELEASES_WEBHOOK_URL:
         required: false
-      GH_PERSONAL_TOKEN:
-        description: "GH token needed for triggering helm chart PR."
+      GH_BOT_CLIENT_ID:
+        description: "GitHub App Client ID."
+        required: true
+      GH_BOT_PRIVATE_KEY:
+        description: "GitHub App private key."
         required: true
     inputs:
       retag-latest:
@@ -214,11 +217,21 @@ jobs:
           regctl image copy ${{ format('kestra/kestra:{0}{1}', steps.vars.outputs.tag, matrix.image.name) }} ${{ format('kestra/kestra:latest-lts{0}', matrix.image.name) }}
 
       # Trigger gha workflow to bump helm chart version
+      - name: Generate token for helm-charts dispatch
+        id: helm-token
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          owner: kestra-io
+          repositories: helm-charts
+
       - name: GitHub - Trigger the Helm chart version bump
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 #v4.0.1
         if: startsWith(github.ref, 'refs/tags/v')
         with:
-          token: ${{ secrets.GH_PERSONAL_TOKEN }}
+          token: ${{ steps.helm-token.outputs.token }}
           repository: kestra-io/helm-charts
           event-type: update-helm-chart-version
           client-payload: |-

--- a/.github/workflows/kestra-oss-publish-github.yml
+++ b/.github/workflows/kestra-oss-publish-github.yml
@@ -3,8 +3,11 @@ name: Github - Release
 on:
   workflow_call:
     secrets:
-      GH_PERSONAL_TOKEN:
-        description: "The Github personal token."
+      GH_BOT_CLIENT_ID:
+        description: "GitHub App Client ID."
+        required: true
+      GH_BOT_PRIVATE_KEY:
+        description: "GitHub App private key."
         required: true
       SLACK_RELEASES_WEBHOOK_URL:
         description: "The Slack webhook URL."
@@ -23,6 +26,15 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
       # Download Exec
       # Must be done after checkout actions
@@ -54,12 +66,12 @@ jobs:
           announce-slack: 'false'
         env:
           MAKE_LATEST: ${{ steps.is_latest.outputs.latest }}
-          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           SLACK_RELEASES_WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
 
       - name: Merge Release Notes
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: kestra-io/actions/composite/github-release-note-merge@main
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TAG: ${{ github.ref_name }}

--- a/composite/after-release/tag-previous-version/action.yml
+++ b/composite/after-release/tag-previous-version/action.yml
@@ -1,16 +1,27 @@
 name: "Tag previous version for versioning"
 
 inputs:
+  gh-app-id:
+    required: true
+    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+  gh-app-private-key:
+    required: true
+    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
   new_version:
     description: "New Kestra version"
-    required: true
-  secrets:
-    description: 'Secrets passed as toJSON'
     required: true
 
 runs:
   using: composite
   steps:
+    - id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.gh-app-id }}
+        private-key: ${{ inputs.gh-app-private-key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+
     - name: Validate Kestra version format
       id: validate-format
       shell: bash
@@ -28,7 +39,7 @@ runs:
       uses: actions/checkout@v5
       with:
         ref: main
-        token: ${{ fromJson(inputs.secrets).GH_PERSONAL_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Read versions and create missing tag
       id: read-latest

--- a/composite/checkout-and-auth/action.yml
+++ b/composite/checkout-and-auth/action.yml
@@ -1,0 +1,60 @@
+name: Checkout and Auth (with GitHub App token)
+description: >
+  Wraps actions/checkout@v4. Generates a short-lived GitHub App installation token
+  scoped to the target repository.
+
+inputs:
+  gh-app-id:
+    required: true
+    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+  gh-app-private-key:
+    required: true
+    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
+  repository:
+    required: false
+    default: ${{ github.repository }}
+    description: Repository to check out in owner/repo format (e.g. kestra-io/kestra). Defaults to the current repository.
+  ref:
+    required: false
+    default: ''
+  path:
+    required: false
+    default: ''
+  fetch-depth:
+    required: false
+    default: '1'
+  submodules:
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - id: repo-meta
+      shell: bash
+      run: |
+        REPO="${{ inputs.repository }}"
+        if [[ "$REPO" == */* ]]; then
+          echo "owner=${REPO%%/*}" >> "$GITHUB_OUTPUT"
+          echo "name=${REPO##*/}" >> "$GITHUB_OUTPUT"
+        else
+          echo "owner=${{ github.repository_owner }}" >> "$GITHUB_OUTPUT"
+          echo "name=$REPO" >> "$GITHUB_OUTPUT"
+        fi
+
+    - id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.gh-app-id }}
+        private-key: ${{ inputs.gh-app-private-key }}
+        owner: ${{ steps.repo-meta.outputs.owner }}
+        repositories: ${{ steps.repo-meta.outputs.name }}
+
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.ref }}
+        path: ${{ inputs.path }}
+        token: ${{ steps.app-token.outputs.token }}
+        fetch-depth: ${{ inputs.fetch-depth }}
+        submodules: ${{ inputs.submodules }}

--- a/composite/gh-cli/action.yml
+++ b/composite/gh-cli/action.yml
@@ -1,0 +1,78 @@
+name: Run gh / shell command (with GitHub App token)
+description: >
+  Generates a short-lived GitHub App installation token, exports it as GH_TOKEN,
+  then executes the provided shell command. Suitable for gh CLI calls, git push
+  over HTTPS, or any shell operation that needs API access.
+
+inputs:
+  gh-app-id:
+    required: true
+    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+  gh-app-private-key:
+    required: true
+    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
+  owner:
+    required: false
+    default: ''
+    description: >
+      GitHub organization or user to scope the token to. When set with an empty
+      `repositories`, creates an installation-wide (org-wide) token. If omitted,
+      the owner is derived from `repositories` or the current repository.
+  repositories:
+    required: false
+    default: ''
+    description: >
+      Comma-separated repositories (owner/repo format) the token may access.
+      Defaults to the current repository. All repositories must share the same
+      owner — the token is scoped to a single GitHub App installation (one owner).
+  run:
+    required: true
+    description: Shell command to execute with GH_TOKEN set in the environment.
+
+runs:
+  using: composite
+  steps:
+    - id: repo-meta
+      shell: bash
+      run: |
+        REPOS="${{ inputs.repositories }}"
+        OWNER_IN="${{ inputs.owner }}"
+
+        if [[ -n "$OWNER_IN" && -z "$REPOS" ]]; then
+          echo "owner=$OWNER_IN" >> "$GITHUB_OUTPUT"
+          echo "names=" >> "$GITHUB_OUTPUT"
+          echo "org_wide=true" >> "$GITHUB_OUTPUT"
+        else
+          if [[ -z "$REPOS" ]]; then
+            REPOS="${{ github.repository }}"
+          fi
+          OWNERS=$(echo "$REPOS" | tr ',' '\n' | sed 's|/.*||' | sort -u | tr '\n' ',' | sed 's/,$//')
+          OWNER=$(echo "$OWNERS" | cut -d',' -f1)
+          if [[ -n "$OWNER_IN" ]]; then OWNER="$OWNER_IN"; fi
+          NAMES=$(echo "$REPOS" | tr ',' '\n' | sed 's|.*/||' | tr '\n' ',' | sed 's/,$//')
+          echo "owner=$OWNER" >> "$GITHUB_OUTPUT"
+          echo "names=$NAMES" >> "$GITHUB_OUTPUT"
+          echo "org_wide=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - id: app-token-org
+      if: ${{ steps.repo-meta.outputs.org_wide == 'true' }}
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.gh-app-id }}
+        private-key: ${{ inputs.gh-app-private-key }}
+        owner: ${{ steps.repo-meta.outputs.owner }}
+
+    - id: app-token-repo
+      if: ${{ steps.repo-meta.outputs.org_wide != 'true' }}
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.gh-app-id }}
+        private-key: ${{ inputs.gh-app-private-key }}
+        owner: ${{ steps.repo-meta.outputs.owner }}
+        repositories: ${{ steps.repo-meta.outputs.names }}
+
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ steps.app-token-org.outputs.token || steps.app-token-repo.outputs.token }}
+      run: ${{ inputs.run }}

--- a/composite/github-script/action.yml
+++ b/composite/github-script/action.yml
@@ -1,0 +1,57 @@
+name: Run github-script (with GitHub App token)
+description: >
+  Wraps actions/github-script@v9. Generates a short-lived GitHub App installation
+  token and passes it as github-token so the Octokit client is authenticated
+  as the App installation.
+
+inputs:
+  gh-app-id:
+    required: true
+    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+  gh-app-private-key:
+    required: true
+    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
+  repositories:
+    required: false
+    default: ''
+    description: >
+      Comma-separated repositories (owner/repo format) the token may access.
+      Defaults to the current repository.
+  script:
+    required: true
+    description: JavaScript code to execute via actions/github-script.
+  result-encoding:
+    required: false
+    default: string
+    description: Either "string" or "json" (passed through to actions/github-script).
+
+runs:
+  using: composite
+  steps:
+    - id: repo-meta
+      shell: bash
+      run: |
+        REPOS="${{ inputs.repositories }}"
+        if [[ -z "$REPOS" ]]; then
+          REPOS="${{ github.repository }}"
+        fi
+
+        OWNER=$(echo "$REPOS" | tr ',' '\n' | sed 's|/.*||' | head -1)
+        NAMES=$(echo "$REPOS" | tr ',' '\n' | sed 's|.*/||' | tr '\n' ',' | sed 's/,$//')
+
+        echo "owner=$OWNER" >> "$GITHUB_OUTPUT"
+        echo "names=$NAMES" >> "$GITHUB_OUTPUT"
+
+    - id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.gh-app-id }}
+        private-key: ${{ inputs.gh-app-private-key }}
+        owner: ${{ steps.repo-meta.outputs.owner }}
+        repositories: ${{ steps.repo-meta.outputs.names }}
+
+    - uses: actions/github-script@v9
+      with:
+        github-token: ${{ steps.app-token.outputs.token }}
+        result-encoding: ${{ inputs.result-encoding }}
+        script: ${{ inputs.script }}

--- a/composite/plugin-release/action.yml
+++ b/composite/plugin-release/action.yml
@@ -14,6 +14,12 @@ name: Release Kestra Plugin
 description: "Release logic for Kestra plugins (MAJOR, MINOR, PATCH, HOTFIX)"
 
 inputs:
+  gh-app-id:
+    required: true
+    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+  gh-app-private-key:
+    required: true
+    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
   releaseVersion:
     required: true
     description: "Release version (e.g. 1.0.0, 1.3.0 or 1.4.2)"
@@ -40,12 +46,20 @@ runs:
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --global user.name "github-actions[bot]"
 
+    - id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.gh-app-id }}
+        private-key: ${{ inputs.gh-app-private-key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: true
-        token: ${{ env.GITHUB_PAT }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Setup - Build
       uses: kestra-io/actions/composite/setup-build@main
@@ -55,7 +69,7 @@ runs:
     - name: Run Release
       shell: bash
       env:
-        GITHUB_PAT: ${{ env.GITHUB_PAT }}
+        GITHUB_PAT: ${{ steps.app-token.outputs.token }}
       run: |
         chmod +x ${{ github.action_path }}/release.sh
         ${{ github.action_path }}/release.sh \

--- a/composite/publish-api-reference/action.yml
+++ b/composite/publish-api-reference/action.yml
@@ -2,20 +2,31 @@ name: "Push API Reference to website"
 description: "This action pushes the API reference changes to the website."
 
 inputs:
-  gh_personal_token:
-    description: 'Github token'
+  gh-app-id:
     required: true
+    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+  gh-app-private-key:
+    required: true
+    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
 
 runs:
   using: composite
   steps:
+    - id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.gh-app-id }}
+        private-key: ${{ inputs.gh-app-private-key }}
+        owner: kestra-io
+        repositories: docs
+
     - name: Checkout - Docs
       uses: actions/checkout@v5
       with:
         repository: kestra-io/docs
         path: docs
         ref: "main"
-        token: ${{ inputs.gh_personal_token }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Artifacts - Download swagger
       uses: actions/download-artifact@v5

--- a/composite/repository-dispatch/action.yml
+++ b/composite/repository-dispatch/action.yml
@@ -1,0 +1,43 @@
+name: Repository Dispatch (with GitHub App token)
+description: Mints a GitHub App token scoped to the target repo, then fires repository_dispatch.
+
+inputs:
+  gh-app-id:
+    required: true
+    description: "GitHub App Client ID"
+  gh-app-private-key:
+    required: true
+    description: "GitHub App private key"
+  repository:
+    required: true
+    description: "owner/repo to dispatch to"
+  event-type:
+    required: true
+    description: "The repository_dispatch event type"
+  client-payload:
+    required: false
+    default: '{}'
+    description: "JSON client payload"
+
+runs:
+  using: composite
+  steps:
+    - id: repo-meta
+      shell: bash
+      run: |
+        REPO="${{ inputs.repository }}"
+        echo "owner=${REPO%%/*}" >> "$GITHUB_OUTPUT"
+        echo "name=${REPO##*/}" >> "$GITHUB_OUTPUT"
+    - id: app-token
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.gh-app-id }}
+        private-key: ${{ inputs.gh-app-private-key }}
+        owner: ${{ steps.repo-meta.outputs.owner }}
+        repositories: ${{ steps.repo-meta.outputs.name }}
+    - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
+      with:
+        token: ${{ steps.app-token.outputs.token }}
+        repository: ${{ inputs.repository }}
+        event-type: ${{ inputs.event-type }}
+        client-payload: ${{ inputs.client-payload }}


### PR DESCRIPTION
Follow-up to the GitHub App token migration.

`actions/create-github-app-token@v3` deprecated the `app-id` input in favour of `client-id`. Update all seven composites accordingly.