### PR TITLE
fix(ci): use client-id instead of deprecated app-id in create-github-app-token

### DIFF
--- a/composite/after-release/tag-previous-version/action.yml
+++ b/composite/after-release/tag-previous-version/action.yml
@@ -17,7 +17,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}

--- a/composite/checkout-and-auth/action.yml
+++ b/composite/checkout-and-auth/action.yml
@@ -45,7 +45,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ steps.repo-meta.outputs.owner }}
         repositories: ${{ steps.repo-meta.outputs.name }}

--- a/composite/gh-cli/action.yml
+++ b/composite/gh-cli/action.yml
@@ -59,7 +59,7 @@ runs:
       if: ${{ steps.repo-meta.outputs.org_wide == 'true' }}
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ steps.repo-meta.outputs.owner }}
 
@@ -67,7 +67,7 @@ runs:
       if: ${{ steps.repo-meta.outputs.org_wide != 'true' }}
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ steps.repo-meta.outputs.owner }}
         repositories: ${{ steps.repo-meta.outputs.names }}

--- a/composite/github-script/action.yml
+++ b/composite/github-script/action.yml
@@ -45,7 +45,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ steps.repo-meta.outputs.owner }}
         repositories: ${{ steps.repo-meta.outputs.names }}

--- a/composite/plugin-release/action.yml
+++ b/composite/plugin-release/action.yml
@@ -49,7 +49,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}

--- a/composite/publish-api-reference/action.yml
+++ b/composite/publish-api-reference/action.yml
@@ -15,7 +15,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: kestra-io
         repositories: docs

--- a/composite/repository-dispatch/action.yml
+++ b/composite/repository-dispatch/action.yml
@@ -31,7 +31,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ steps.repo-meta.outputs.owner }}
         repositories: ${{ steps.repo-meta.outputs.name }}


### PR DESCRIPTION
Follow-up to #98.

`actions/create-github-app-token@v3` deprecated the `app-id` input in favour of `client-id`. Update all seven composites accordingly.