### PR TITLE
fix(ci): use GH_BOT_APP_ID instead of GH_BOT_CLIENT_ID for GitHub App token

### DIFF
--- a/.github/workflows/kestra-ee-publish-github.yml
+++ b/.github/workflows/kestra-ee-publish-github.yml
@@ -3,7 +3,7 @@ name: Github - Release
 on:
   workflow_call:
     secrets:
-      GH_BOT_CLIENT_ID:
+      GH_BOT_APP_ID:
         description: "GitHub App Client ID."
         required: true
       GH_BOT_PRIVATE_KEY:
@@ -31,7 +31,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }},docs
@@ -63,7 +63,7 @@ jobs:
         uses: kestra-io/actions/composite/publish-api-reference@main
         if: ${{ steps.is_latest.outputs.latest == 'true' }}
         with:
-          gh-app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          gh-app-id: ${{ secrets.GH_BOT_APP_ID }}
           gh-app-private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
 
       # GitHub Release

--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -13,7 +13,7 @@ on:
         required: true
       SLACK_RELEASES_WEBHOOK_URL:
         required: false
-      GH_BOT_CLIENT_ID:
+      GH_BOT_APP_ID:
         description: "GitHub App Client ID."
         required: true
       GH_BOT_PRIVATE_KEY:
@@ -222,7 +222,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           owner: kestra-io
           repositories: helm-charts

--- a/.github/workflows/kestra-oss-publish-github.yml
+++ b/.github/workflows/kestra-oss-publish-github.yml
@@ -3,7 +3,7 @@ name: Github - Release
 on:
   workflow_call:
     secrets:
-      GH_BOT_CLIENT_ID:
+      GH_BOT_APP_ID:
         description: "GitHub App Client ID."
         required: true
       GH_BOT_PRIVATE_KEY:
@@ -31,7 +31,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_BOT_CLIENT_ID }}
+          app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}


### PR DESCRIPTION
Follow-up to #98.

`GH_BOT_CLIENT_ID` is the OAuth client ID (not suitable for App JWT auth). `GH_BOT_APP_ID` is the correct secret for minting installation tokens via `actions/create-github-app-token`.