### PR TITLE
fix(ci): migrate create-github-app-token to client-id and remove secrets expressions from composite action descriptions

### DIFF
--- a/composite/after-release/tag-previous-version/action.yml
+++ b/composite/after-release/tag-previous-version/action.yml
@@ -3,10 +3,10 @@ name: "Tag previous version for versioning"
 inputs:
   gh-app-id:
     required: true
-    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+    description: GitHub App Client ID (pass secrets.GH_BOT_CLIENT_ID from the caller workflow).
   gh-app-private-key:
     required: true
-    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
+    description: GitHub App private key (pass secrets.GH_BOT_PRIVATE_KEY from the caller workflow).
   new_version:
     description: "New Kestra version"
     required: true

--- a/composite/after-release/tag-previous-version/action.yml
+++ b/composite/after-release/tag-previous-version/action.yml
@@ -17,7 +17,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}

--- a/composite/checkout-and-auth/action.yml
+++ b/composite/checkout-and-auth/action.yml
@@ -6,10 +6,10 @@ description: >
 inputs:
   gh-app-id:
     required: true
-    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+    description: GitHub App Client ID (pass secrets.GH_BOT_CLIENT_ID from the caller workflow).
   gh-app-private-key:
     required: true
-    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
+    description: GitHub App private key (pass secrets.GH_BOT_PRIVATE_KEY from the caller workflow).
   repository:
     required: false
     default: ${{ github.repository }}

--- a/composite/checkout-and-auth/action.yml
+++ b/composite/checkout-and-auth/action.yml
@@ -45,7 +45,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ steps.repo-meta.outputs.owner }}
         repositories: ${{ steps.repo-meta.outputs.name }}

--- a/composite/gh-cli/action.yml
+++ b/composite/gh-cli/action.yml
@@ -59,7 +59,7 @@ runs:
       if: ${{ steps.repo-meta.outputs.org_wide == 'true' }}
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ steps.repo-meta.outputs.owner }}
 
@@ -67,7 +67,7 @@ runs:
       if: ${{ steps.repo-meta.outputs.org_wide != 'true' }}
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ steps.repo-meta.outputs.owner }}
         repositories: ${{ steps.repo-meta.outputs.names }}

--- a/composite/gh-cli/action.yml
+++ b/composite/gh-cli/action.yml
@@ -7,10 +7,10 @@ description: >
 inputs:
   gh-app-id:
     required: true
-    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+    description: GitHub App Client ID (pass secrets.GH_BOT_CLIENT_ID from the caller workflow).
   gh-app-private-key:
     required: true
-    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
+    description: GitHub App private key (pass secrets.GH_BOT_PRIVATE_KEY from the caller workflow).
   owner:
     required: false
     default: ''

--- a/composite/github-script/action.yml
+++ b/composite/github-script/action.yml
@@ -7,10 +7,10 @@ description: >
 inputs:
   gh-app-id:
     required: true
-    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+    description: GitHub App Client ID (pass secrets.GH_BOT_CLIENT_ID from the caller workflow).
   gh-app-private-key:
     required: true
-    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
+    description: GitHub App private key (pass secrets.GH_BOT_PRIVATE_KEY from the caller workflow).
   repositories:
     required: false
     default: ''

--- a/composite/github-script/action.yml
+++ b/composite/github-script/action.yml
@@ -45,7 +45,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ steps.repo-meta.outputs.owner }}
         repositories: ${{ steps.repo-meta.outputs.names }}

--- a/composite/plugin-release/action.yml
+++ b/composite/plugin-release/action.yml
@@ -16,10 +16,10 @@ description: "Release logic for Kestra plugins (MAJOR, MINOR, PATCH, HOTFIX)"
 inputs:
   gh-app-id:
     required: true
-    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+    description: GitHub App Client ID (pass secrets.GH_BOT_CLIENT_ID from the caller workflow).
   gh-app-private-key:
     required: true
-    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
+    description: GitHub App private key (pass secrets.GH_BOT_PRIVATE_KEY from the caller workflow).
   releaseVersion:
     required: true
     description: "Release version (e.g. 1.0.0, 1.3.0 or 1.4.2)"

--- a/composite/plugin-release/action.yml
+++ b/composite/plugin-release/action.yml
@@ -49,7 +49,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}

--- a/composite/publish-api-reference/action.yml
+++ b/composite/publish-api-reference/action.yml
@@ -4,10 +4,10 @@ description: "This action pushes the API reference changes to the website."
 inputs:
   gh-app-id:
     required: true
-    description: GitHub App Client ID (pass ${{ secrets.GH_BOT_CLIENT_ID }}).
+    description: GitHub App Client ID (pass secrets.GH_BOT_CLIENT_ID from the caller workflow).
   gh-app-private-key:
     required: true
-    description: GitHub App private key (pass ${{ secrets.GH_BOT_PRIVATE_KEY }}).
+    description: GitHub App private key (pass secrets.GH_BOT_PRIVATE_KEY from the caller workflow).
 
 runs:
   using: composite

--- a/composite/publish-api-reference/action.yml
+++ b/composite/publish-api-reference/action.yml
@@ -15,7 +15,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: kestra-io
         repositories: docs

--- a/composite/repository-dispatch/action.yml
+++ b/composite/repository-dispatch/action.yml
@@ -31,7 +31,7 @@ runs:
     - id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.gh-app-id }}
+        client-id: ${{ inputs.gh-app-id }}
         private-key: ${{ inputs.gh-app-private-key }}
         owner: ${{ steps.repo-meta.outputs.owner }}
         repositories: ${{ steps.repo-meta.outputs.name }}


### PR DESCRIPTION
- Migrate `app-id` → `client-id` in all composite actions using `actions/create-github-app-token` (v3 renamed the input)
- Remove `${{ secrets.GH_BOT_* }}` from composite action input `description` fields — GitHub's template engine evaluates these expressions even in descriptions, but `secrets` context is unavailable in composite actions, breaking template validation before any step ran