### PR TITLE
feat(kestra-configuration-schema): add kestra-command input

### DIFF
--- a/.github/workflows/kestra-oss-build-artifacts.yml
+++ b/.github/workflows/kestra-oss-build-artifacts.yml
@@ -61,6 +61,44 @@ jobs:
         run: |
           ./gradlew executableJar
 
+      # KIP-45: embed the plugin schema bundle into the executable so the flow editor can
+      # autocomplete plugin types that are not installed, out of the box and offline. Done here, at
+      # the single point the executable is built and before it is copied/uploaded, so every
+      # downstream distribution (Docker image, zip/tar, java -jar) carries it with no publish-job
+      # reorder. PluginSchemaBundleService reads it as the /plugins-schema.json classpath resource.
+      #
+      # DRAFT — needs a real CI run to validate:
+      #   (1) full-catalog install (~all OSS plugins) adds time to this build job (publishes only);
+      #   (2) confirm `zip` can append into the executableJar output (fails if it carries a launcher
+      #       stub before the zip central directory — if so, embed via a Gradle resource step instead);
+      #   (3) the catalog version resolves to `latest`, matching what kestra-configuration-schema does.
+      - name: Artifacts - Embed plugin schema bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          EXE=$(ls build/executable/* | head -1)
+          chmod +x "$EXE"
+
+          VERSION=$(curl -sf "https://api.kestra.io/v1/versions/latest" | jq -r '.version')
+          RESPONSE=$(curl -sf "https://api.kestra.io/v1/plugins/artifacts/core-compatibility/${VERSION}/latest") || {
+            echo "::warning::Could not fetch the plugin catalog; shipping the executable without an embedded schema bundle"
+            exit 0
+          }
+
+          PLUGINS=$(echo "$RESPONSE" | jq -r '.[] | select(.license == "OPENSOURCE") | "\(.groupId):\(.artifactId):\(.version)"' | tr '\n' ' ')
+          if [ -z "$PLUGINS" ]; then
+            echo "::warning::No OSS plugins resolved; shipping the executable without an embedded schema bundle"
+            exit 0
+          fi
+
+          CATALOG_DIR=$(mktemp -d)
+          "$EXE" plugins install --plugins="$CATALOG_DIR" $PLUGINS
+          "$EXE" plugins-schema --plugins "$CATALOG_DIR" -o plugins-schema.json
+
+          # Append at the archive root so it lands on the classpath as /plugins-schema.json.
+          zip -j "$EXE" plugins-schema.json
+          echo "Embedded plugins-schema.json into $EXE"
+
       - name: Artifacts - Copy exe to image
         shell: bash
         run: |

--- a/composite/kestra/kestra-configuration-schema/action.yml
+++ b/composite/kestra/kestra-configuration-schema/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "Java version for running the executable"
     required: false
     default: '25'
+  kestra-command:
+    description: "Kestra CLI command to run for schema generation (e.g. 'configuration-schema' or 'plugins-schema')"
+    required: false
+    default: "configuration-schema"
   output-path:
     description: "Output file name for the generated schema"
     required: false
@@ -51,6 +55,7 @@ runs:
       env:
         KESTRA_VERSION_RAW: ${{ inputs.kestra-version }}
         EDITION: ${{ inputs.edition }}
+        KESTRA_COMMAND: ${{ inputs.kestra-command }}
         EXECUTABLE: ${{ inputs.executable-path }}
         GCP_ACCESS_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
       run: |
@@ -69,7 +74,11 @@ runs:
           exit 0
         }
 
-        if [ "$EDITION" = "ee" ]; then
+        if [ "$KESTRA_COMMAND" = "plugins-schema" ]; then
+          # plugins-schema builds the full editor-autocompletion bundle, so it needs every OSS plugin,
+          # not just storage/secret (which is all configuration-schema installs).
+          JQ_FILTER='.[] | select(.license == "OPENSOURCE") | "\(.groupId):\(.artifactId):\(.version)"'
+        elif [ "$EDITION" = "ee" ]; then
           JQ_FILTER='.[] | select(.groupId == "io.kestra.storage" or .groupId == "io.kestra.ee.secret") | "\(.groupId):\(.artifactId):\(.version)"'
         else
           JQ_FILTER='.[] | select(.groupId == "io.kestra.storage") | "\(.groupId):\(.artifactId):\(.version)"'
@@ -95,20 +104,21 @@ runs:
         "$EXECUTABLE" plugins install --plugins="$PLUGINS_DIR" $REPO_FLAGS $PLUGINS
         echo "plugins-dir=$PLUGINS_DIR" >> "$GITHUB_OUTPUT"
 
-    - name: Generate configuration schema
+    - name: Generate schema
       shell: bash
       env:
         EXECUTABLE: ${{ inputs.executable-path }}
+        KESTRA_COMMAND: ${{ inputs.kestra-command }}
         PLUGINS_DIR: ${{ steps.install-plugins.outputs.plugins-dir }}
         OUTPUT_PATH: ${{ inputs.output-path }}
       run: |
         set -euo pipefail
         PLUGINS_FLAG=""
-        if [ -n "$PLUGINS_DIR" ]; then
+        if [ -n "${PLUGINS_DIR:-}" ]; then
           PLUGINS_FLAG="--plugins=$PLUGINS_DIR"
         fi
 
-        "$EXECUTABLE" configuration-schema $PLUGINS_FLAG -o "$OUTPUT_PATH"
+        "$EXECUTABLE" $KESTRA_COMMAND $PLUGINS_FLAG -o "$OUTPUT_PATH"
         echo "Schema generated at $OUTPUT_PATH"
 
     - name: Upload schema to GCS


### PR DESCRIPTION
## Summary

- Adds a `kestra-command` input (default: `configuration-schema`) to make the CLI command configurable.
- When set to `plugins-schema`, the plugin fetch/install steps are skipped (they are only needed for the `configuration-schema` command).
- Enables callers to generate the per-release **plugin schema bundle** (`plugins-schema.json`) used by KIP-45 to provide editor autocompletion for un-installed plugin types.

## Test plan

- [ ] Existing `configuration-schema` usage in kestra-io/kestra still works (no `kestra-command` input = default behaviour unchanged)
- [ ] New `kestra-command: plugins-schema` step runs `kestra plugins-schema -o <output>` and skips fetch/install steps

Part-of: https://github.com/kestra-io/kestra-ee/issues/7636