### PR TITLE
fix(security): scope secrets to required inputs per composite action

### DIFF
--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -89,4 +89,6 @@ jobs:
         uses: kestra-io/actions/composite/report-java@main
         if: ${{ !cancelled() }}
         with:
-          secrets: ${{ toJSON(secrets) }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          google-service-account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/kestra-oss-backend-tests.yml
+++ b/.github/workflows/kestra-oss-backend-tests.yml
@@ -84,4 +84,8 @@ jobs:
         uses: kestra-io/actions/composite/report-java@main
         if: ${{ !cancelled() }}
         with:
-          secrets: ${{ toJSON(secrets) }}
+          github-token: ${{ secrets.GITHUB_AUTH_TOKEN }}
+          google-service-account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          github-auth-token: ${{ secrets.GITHUB_AUTH_TOKEN }}

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -88,11 +88,14 @@ jobs:
           java-version: ${{ startsWith(inputs.kestra-version, '2.') && env.COMPATIBILITY_JAVA_VERSION || inputs.java-version }}
           java-enable-develocity-injection: true
 
-      # Setup for setup-unit.sh, injecting secrets as env variables
+      # Setup for setup-unit.sh, injecting only non-sensitive secrets as env variables.
+      # GITHUB_TOKEN and known infra secrets are excluded; plugin tests should use
+      # explicitly declared secrets in their own workflow_call secrets block.
       - name: Setup - Secret to Env
         uses: oNaiPs/secrets-to-env-action@v1
         with:
           secrets: ${{ toJSON(secrets) }}
+          exclude: GITHUB_TOKEN, GH_BOT_APP_ID, GH_BOT_PRIVATE_KEY, SONATYPE_USER, SONATYPE_PASSWORD, SONATYPE_GPG_KEYID, SONATYPE_GPG_PASSWORD, SONATYPE_GPG_FILE, SLACK_WEBHOOK_URL, SLACK_RELEASES_WEBHOOK_URL, KESTRA_WEBHOOK_URL_PLUGIN_RELEASE_INDEX
 
       # Auth to google with github are required for com.google.cloud.artifactregistry.gradle-plugin
       - name: GCP - Auth with github service account
@@ -169,15 +172,19 @@ jobs:
         uses: kestra-io/actions/composite/publish-java@main
         if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && startsWith(github.repository, 'kestra-io/') && steps.publish-guard.outputs.should-publish == 'true' }}
         with:
-          secrets: ${{ toJSON(secrets) }}
           is-private: ${{ inputs.sonatype-publish == false }}
+          sonatype-user: ${{ secrets.SONATYPE_USER }}
+          sonatype-password: ${{ secrets.SONATYPE_PASSWORD }}
+          sonatype-gpg-keyid: ${{ secrets.SONATYPE_GPG_KEYID }}
+          sonatype-gpg-password: ${{ secrets.SONATYPE_GPG_PASSWORD }}
+          sonatype-gpg-file: ${{ secrets.SONATYPE_GPG_FILE }}
 
       # Upload JAR for PR
       - name: Publish - Jar artifacts for PR only
         uses: kestra-io/actions/composite/jar-upload@main
         if: ${{ inputs.generate-shadowjar == true && github.event_name == 'pull_request' && startsWith(github.repository, 'kestra-io/') }}
         with:
-          secrets: ${{ toJSON(secrets) }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Cleanup disk space to avoid "no space left on device" errors during Trivy scan
       - name: Cleanup - Free up disk space
@@ -211,7 +218,7 @@ jobs:
         if: ${{ inputs.generate-shadowjar == true && github.event_name == 'pull_request' && startsWith(github.repository, 'kestra-io/') }}
         uses: kestra-io/actions/composite/scan-trivy@main
         with:
-          secrets: ${{ toJSON(secrets) }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # GitHub Release
       - name: GitHub - Create release
@@ -226,14 +233,18 @@ jobs:
         uses: kestra-io/actions/composite/report-java@main
         if: ${{ !cancelled() && inputs.skip-test == false }}
         with:
-          secrets: ${{ toJSON(secrets) }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          google-service-account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          github-auth-token: ${{ secrets.GITHUB_AUTH_TOKEN }}
 
       # Unreleased commits since latest release
       - name: Unreleased Commits - Comment pull request
         uses: kestra-io/actions/composite/unreleased-commits@main
         if: ${{ github.event_name == 'pull_request' }}
         with:
-          secrets: ${{ toJSON(secrets) }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Slack on error
       - name: Slack - Notify on failure

--- a/composite/after-release/global/action.yml
+++ b/composite/after-release/global/action.yml
@@ -4,8 +4,8 @@ inputs:
   new_version:
     description: "New Kestra version"
     required: false
-  secrets:
-    description: 'Secrets passed as toJSON'
+  after-release-ee-webhook:
+    description: 'Webhook URL to trigger the after-release EE workflow'
     required: true
 
 runs:
@@ -60,4 +60,4 @@ runs:
         fi
         
         # TODO ADD WEBHOOK TO INPUTS
-        curl -X POST -H "Content-Type: application/json" -d "{\"TO_RELEASE\": ${TO_RELEASE},\"RELEASED_VERSION\":\"${VER}\"}" ${{ fromJson(inputs.secrets).AFTER_RELEASE_EE_WEBHOOK }}
+        curl -X POST -H "Content-Type: application/json" -d "{\"TO_RELEASE\": ${TO_RELEASE},\"RELEASED_VERSION\":\"${VER}\"}" ${{ inputs.after-release-ee-webhook }}

--- a/composite/jar-upload/action.yml
+++ b/composite/jar-upload/action.yml
@@ -2,8 +2,8 @@ name: 'Upload Jar'
 description: 'This action uploads the jar as artifact and comments the download link on the pull request'
 
 inputs:
-  secrets:
-    description: 'Secrets passed as toJSON'
+  github-token:
+    description: 'GitHub token for PR comments'
     required: true
 
 runs:
@@ -20,7 +20,7 @@ runs:
       uses: kestra-io/actions/actions/comment-update@main
       continue-on-error: true
       with:
-        github-token: ${{ fromJson(inputs.secrets).GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token }}
         title: "📦 Artifacts"
         fetch-artifact: 'true'
         add-summary: 'false'

--- a/composite/publish-java/action.yml
+++ b/composite/publish-java/action.yml
@@ -6,9 +6,25 @@ inputs:
     description: 'Does we push to private maven registry'
     required: true
 
-  secrets:
-    description: 'Secrets passed as toJSON'
-    required: true
+  sonatype-user:
+    description: 'Sonatype username for Maven Central publishing'
+    required: false
+
+  sonatype-password:
+    description: 'Sonatype password for Maven Central publishing'
+    required: false
+
+  sonatype-gpg-keyid:
+    description: 'GPG key ID for signing Maven Central artifacts'
+    required: false
+
+  sonatype-gpg-password:
+    description: 'GPG key passphrase for signing Maven Central artifacts'
+    required: false
+
+  sonatype-gpg-file:
+    description: 'Base64-encoded GPG secret keyring for signing Maven Central artifacts'
+    required: false
 
 runs:
   using: composite
@@ -51,11 +67,11 @@ runs:
     - name: Publish - Release package to Maven Central
       if: ${{ inputs.is-private == 'false' }}
       env:
-        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ fromJson(inputs.secrets).SONATYPE_USER }}
-        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ fromJson(inputs.secrets).SONATYPE_PASSWORD }}
-        SONATYPE_GPG_KEYID: ${{ fromJson(inputs.secrets).SONATYPE_GPG_KEYID }}
-        SONATYPE_GPG_PASSWORD: ${{ fromJson(inputs.secrets).SONATYPE_GPG_PASSWORD }}
-        SONATYPE_GPG_FILE: ${{ fromJson(inputs.secrets).SONATYPE_GPG_FILE }}
+        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ inputs.sonatype-user }}
+        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ inputs.sonatype-password }}
+        SONATYPE_GPG_KEYID: ${{ inputs.sonatype-gpg-keyid }}
+        SONATYPE_GPG_PASSWORD: ${{ inputs.sonatype-gpg-password }}
+        SONATYPE_GPG_FILE: ${{ inputs.sonatype-gpg-file }}
       shell: bash
       run: |
         echo "signing.keyId=${SONATYPE_GPG_KEYID}" > ~/.gradle/gradle.properties

--- a/composite/report-java/action.yml
+++ b/composite/report-java/action.yml
@@ -6,9 +6,26 @@ inputs:
     description: 'Run Sonar analysis'
     required: false
     default: 'true'
-  secrets:
-    description: 'Secrets passed as toJSON'
-    required: true
+
+  github-token:
+    description: 'GitHub token for PR comments and test report scripts'
+    required: false
+
+  google-service-account:
+    description: 'Google Service Account JSON for Allure/Jacoco GCS uploads'
+    required: false
+
+  codecov-token:
+    description: 'Codecov token for coverage and test results upload'
+    required: false
+
+  sonar-token:
+    description: 'Sonar token for analysis'
+    required: false
+
+  github-auth-token:
+    description: 'GitHub auth token for Sonar analysis'
+    required: false
 
 runs:
   using: composite
@@ -36,7 +53,7 @@ runs:
       continue-on-error: true
       if: ${{ github.event_name == 'pull_request' && startsWith(github.repository, 'kestra-io/') }}
       with:
-        github-token: ${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token }}
         title: "🧪 Java Unit Tests"
         template: |
           ${{ steps.test-report.outputs.summary }}
@@ -48,18 +65,18 @@ runs:
       if: ${{ !cancelled() && github.event_name == 'pull_request' && startsWith(github.repository, 'kestra-io/') }}
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: npx --yes @kestra-io/kestra-devtools generateTestReportSummary --only-errors --ci $(pwd)
 
     # GCP
     - name: GCP - Auth with unit test account
-      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT != '' }}
+      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && inputs.google-service-account != '' }}
       uses: 'google-github-actions/auth@v3'
       with:
-        credentials_json: '${{ fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT }}'
+        credentials_json: '${{ inputs.google-service-account }}'
 
     - name: GCP - Setup Cloud SDK
-      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT != ''}}
+      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && inputs.google-service-account != '' }}
       uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: GCP - Configure project and location
@@ -71,12 +88,12 @@ runs:
     # Allure
     - name: Allure - Generate reports
       shell: bash
-      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT != ''}}
+      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && inputs.google-service-account != '' }}
       continue-on-error: true
       run: |
         gcloud storage cp -r gs://internal-kestra-host/${{ github.repository }}/allure/java/history build/allure-results/
-        docker run --rm -v $PWD:/work tobix/allure-cli generate /work/build/allure-results/ -o /work/build/reports/allure --clean 
-        
+        docker run --rm -v $PWD:/work tobix/allure-cli generate /work/build/allure-results/ -o /work/build/reports/allure --clean
+
         if [ -d build/reports/allure/ ]; then
           gsutil -m rsync -d -r  build/reports/allure/ gs://internal-kestra-host/${{ format('{0}/{1}', github.repository, 'allure/java') }}
         fi
@@ -84,14 +101,14 @@ runs:
     # Jacoco
     - name: Jacoco - Copy reports
       shell: bash
-      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT != ''}}
+      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && inputs.google-service-account != '' }}
       continue-on-error: true
       run: |
         if [ -d build/reports/jacoco/testCodeCoverageReport ]; then
           cp -R build/reports/jacoco/testCodeCoverageReport build/reports/jacoco/test/
           cp build/reports/jacoco/test/testCodeCoverageReport.xml build/reports/jacoco/test/jacocoTestReport.xml
         fi
-        
+
         if [ -d build/reports/jacoco/test/ ]; then
           gsutil -m rsync -d -r  build/reports/jacoco/test/ gs://internal-kestra-host/${{ format('{0}/{1}', github.repository, 'jacoco') }}
         fi
@@ -102,14 +119,14 @@ runs:
       if: ${{ job.status == 'success' }}
       continue-on-error: true
       with:
-        token: ${{ fromJSON(inputs.secrets).CODECOV_TOKEN }}
+        token: ${{ inputs.codecov-token }}
 
     - name: Codecov - Upload test results
       uses: codecov/test-results-action@v1
       if: ${{ job.status == 'success' }}
       continue-on-error: true
       with:
-        token: ${{ fromJSON(inputs.secrets).CODECOV_TOKEN }}
+        token: ${{ inputs.codecov-token }}
 
     # Gradle dependency
     - name: Java - Gradle dependency graph
@@ -123,8 +140,8 @@ runs:
     - name: Sonar - Analyze with Sonar
       if: ${{ job.status == 'success' && inputs.run-sonar == 'true' && env.SONAR_TOKEN != '' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') }}
       env:
-        GITHUB_TOKEN: ${{ fromJSON(inputs.secrets).GITHUB_AUTH_TOKEN }}
-        SONAR_TOKEN: ${{ fromJSON(inputs.secrets).SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.github-auth-token }}
+        SONAR_TOKEN: ${{ inputs.sonar-token }}
       shell: bash
       continue-on-error: true
       run: ./gradlew sonar

--- a/composite/scan-trivy/action.yml
+++ b/composite/scan-trivy/action.yml
@@ -12,8 +12,8 @@ inputs:
     required: false
     default: "*/build/libs/*.jar"
 
-  secrets:
-    description: 'Secrets passed as toJSON'
+  github-token:
+    description: 'GitHub token for PR comments'
     required: true
 
 runs:
@@ -47,7 +47,7 @@ runs:
       uses: kestra-io/actions/actions/comment-update@main
       continue-on-error: true
       with:
-        github-token: ${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token }}
         title: "🛡 Trivy"
         files: |
           ${{ github.workspace }}/trivy-result.json
@@ -60,7 +60,7 @@ runs:
           | Vulnerability | Severity | Package | Installed Version | Fixed Version |
           | :--- | :--- | :--- | :--- | :--- |
           {%- for vulnerability in suite.Vulnerabilities %}
-          | [{{ vulnerability.VulnerabilityID }}]({{ vulnerability.PrimaryURL }}) | {{ vulnerability.Severity }} | {{ vulnerability.PkgName }} | {{ vulnerability.InstalledVersion }} | {{ vulnerability.FixedVersion }} |          
+          | [{{ vulnerability.VulnerabilityID }}]({{ vulnerability.PrimaryURL }}) | {{ vulnerability.Severity }} | {{ vulnerability.PkgName }} | {{ vulnerability.InstalledVersion }} | {{ vulnerability.FixedVersion }} |
           {%- endfor %}
           {% endif %}
           {%- endfor %}

--- a/composite/unreleased-commits/action.yaml
+++ b/composite/unreleased-commits/action.yaml
@@ -2,8 +2,8 @@ name: 'Unreleased Commits'
 description: 'Comment unreleased commits since latest tag'
 
 inputs:
-  secrets:
-    description: 'Secrets passed as toJSON'
+  github-token:
+    description: 'GitHub token for PR comments'
     required: true
 
 runs:
@@ -13,13 +13,13 @@ runs:
       uses: kestra-io/actions/actions/comment-update@main
       continue-on-error: true
       with:
-        github-token: ${{ fromJson(inputs.secrets).GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token }}
         title: "🔁 Unreleased Commits"
         fetch-unreleased-commits: true
         template: |
           {% if unreleased and unreleased.commits | length > 0 %}
           {{ unreleased.commits | length }} commits since [`{{ unreleased.latestTag }}`](https://github.com/${{ github.repository }}/compare/{{ unreleased.latestTag }}...main)
-          
+
           | SHA | Title | Author | Date |
           | :--- | :------ | :------ | :---- |
           {%- for c in unreleased.commits %}


### PR DESCRIPTION
## Summary

- Replaces the `secrets: ${{ toJSON(secrets) }}` anti-pattern in all composite actions — this blob exposed the **entire** secrets context to every step, including the Trivy scanner (root cause of kestra-io/kestra-ee#7220)
- Each composite action now declares explicit named inputs for only the secrets it actually needs; callers pass them individually
- Adds an `exclude` list to the `secrets-to-env-action` step in `plugins.yml` to block infrastructure/publishing secrets (`GITHUB_TOKEN`, `GH_BOT_*`, `SONATYPE_*`, `SLACK_*`, webhook URLs) from leaking into the plugin test environment

## Actions changed

| Action | Before | After |
| :--- | :--- | :--- |
| `composite/publish-java` | `secrets` blob | `sonatype-user`, `sonatype-password`, `sonatype-gpg-keyid`, `sonatype-gpg-password`, `sonatype-gpg-file` |
| `composite/jar-upload` | `secrets` blob | `github-token` |
| `composite/scan-trivy` | `secrets` blob | `github-token` |
| `composite/report-java` | `secrets` blob | `github-token`, `google-service-account`, `codecov-token`, `sonar-token`, `github-auth-token` |
| `composite/unreleased-commits` | `secrets` blob | `github-token` |
| `composite/after-release/global` | `secrets` blob | `after-release-ee-webhook` |

## Callers updated

- `.github/workflows/plugins.yml`
- `.github/workflows/kestra-oss-backend-tests.yml`
- `.github/workflows/kestra-ee-backend-tests.yml`

## Notes

The `secrets-to-env-action` step in `plugins.yml` still uses `toJSON(secrets)` because plugin tests rely on arbitrary env vars injected via `setup-unit.sh` (the set varies per plugin). The `exclude` list is a best-effort guard; a proper follow-up would be to have each plugin's caller workflow declare only the secrets its `setup-unit.sh` needs.

Closes kestra-io/kestra-ee#7220