### PR TITLE
ci: add BASE_IMAGE selection and plugins-job gate to kestra-oss-publish-docker

### DIFF
--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -54,7 +54,7 @@ on:
         type: boolean
         default: true
       use-kestra-base-images:
-        description: 'Use kestra-base images and kestractl for plugin download. Default false preserves backward compatibility with older release branches (v0.22–v1.3).'
+        description: 'Use kestra-base images and kestractl for plugin download. Selects the correct kestra-base image variant based on java-version. Set to true for new releases (v1.4+), leave false for old releases to preserve existing behavior.'
         required: false
         type: boolean
         default: false
@@ -63,6 +63,7 @@ jobs:
   plugins:
     name: List Plugins
     runs-on: ubuntu-latest
+    if: ${{ !inputs.use-kestra-base-images }}
     outputs:
       plugins: ${{ steps.plugins-outputs-step.outputs.plugins }}
     steps:
@@ -115,10 +116,14 @@ jobs:
         image:
           - name: "-no-plugins"
             plugins: ""
+            base-image-jre25: "ghcr.io/kestra-io/kestra-base:latest-no-plugins"
+            base-image-jre21: "ghcr.io/kestra-io/kestra-base:latest-jre21-no-plugins"
             packages: jattach
             python-libs: ""
           - name: ""
             plugins: ${{needs.plugins.outputs.plugins}}
+            base-image-jre25: "ghcr.io/kestra-io/kestra-base:latest"
+            base-image-jre21: "ghcr.io/kestra-io/kestra-base:latest-jre21"
             packages: python3 python-is-python3 python3-pip curl jattach
             python-libs: kestra
     steps:
@@ -225,6 +230,7 @@ jobs:
           cache-from: type=gha,scope=docker${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=docker${{ matrix.image.name }}
           build-args: |
+            BASE_IMAGE=${{ inputs.use-kestra-base-images && (inputs.java-version == '21' && matrix.image.base-image-jre21 || matrix.image.base-image-jre25) || 'ghcr.io/kestra-io/kestra-base:latest-no-plugins' }}
             KESTRA_PLUGINS=${{ !inputs.use-kestra-base-images && steps.vars.outputs.plugins || '' }}
             APT_PACKAGES=${{ matrix.image.packages }}
             PYTHON_LIBRARIES=${{ matrix.image.python-libs }}

--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -116,13 +116,13 @@ jobs:
         image:
           - name: "-no-plugins"
             plugins: ""
-            base-image-jre25: "ghcr.io/kestra-io/kestra-base:latest-no-plugins"
+            base-image-jre25: "ghcr.io/kestra-io/kestra-base:latest-jre25-no-plugins"
             base-image-jre21: "ghcr.io/kestra-io/kestra-base:latest-jre21-no-plugins"
             packages: jattach
             python-libs: ""
           - name: ""
             plugins: ${{needs.plugins.outputs.plugins}}
-            base-image-jre25: "ghcr.io/kestra-io/kestra-base:latest"
+            base-image-jre25: "ghcr.io/kestra-io/kestra-base:latest-jre25"
             base-image-jre21: "ghcr.io/kestra-io/kestra-base:latest-jre21"
             packages: python3 python-is-python3 python3-pip curl jattach
             python-libs: kestra


### PR DESCRIPTION
## Summary

Extends the existing `use-kestra-base-images` input to also:

1. **Skip the `plugins` job** when `use-kestra-base-images: true` — the plugin list from the API is not needed when kestractl handles the download directly in CI
2. **Select the correct `BASE_IMAGE`** based on `java-version` and whether the image variant includes Python:
   - `java-version: 21` + full image → `kestra-base:latest-jre21`
   - `java-version: 21` + no-plugins → `kestra-base:latest-jre21-no-plugins`
   - `java-version: 25` (default) + full image → `kestra-base:latest-jre25`
   - `java-version: 25` + no-plugins → `kestra-base:latest-jre25-no-plugins`
3. **Passes `BASE_IMAGE` as a Docker build-arg** (new path) instead of relying on the Dockerfile default

The matrix gains `base-image-jre25` and `base-image-jre21` fields to express the correct base per variant.

## Backward compatibility

When `use-kestra-base-images: false` (default — all old release branches v0.22–v1.3):
- `plugins` job runs as before
- `BASE_IMAGE` falls back to `ghcr.io/kestra-io/kestra-base:latest-no-plugins`
- `KESTRA_PLUGINS` / `APT_PACKAGES` / `PYTHON_LIBRARIES` passed as before
- Zero behavior change

## Merge order

> ⚠️ **Merge kestra#16613** first (`ci/base-image-jre21-python`) — adds JRE-21 and Python variants to `kestra-base`. Then trigger `global-push-base-image` to publish them. Then merge this PR, then the `main-build.yml` wiring.

## Test plan

- [ ] Trigger release dry-run with `use-kestra-base-images: true` + `java-version: 25` — verify `BASE_IMAGE=ghcr.io/kestra-io/kestra-base:latest-jre25` in build-args
- [ ] Same with `java-version: 21` — verify `BASE_IMAGE=kestra-base:latest-jre21`
- [ ] Trigger with `use-kestra-base-images: false` (old path) — verify `plugins` job runs, `KESTRA_PLUGINS` is set, no `BASE_IMAGE` override