### PR TITLE
fix: retry maven central publish on sonatype 403

### DIFF
--- a/composite/publish-java/action.yml
+++ b/composite/publish-java/action.yml
@@ -63,16 +63,21 @@ runs:
         echo "signing.secretKeyRingFile=${HOME}/.gradle/secring.gpg" >> ~/.gradle/gradle.properties
         echo ${SONATYPE_GPG_FILE} | base64 -d > ~/.gradle/secring.gpg
 
-        set +e
-        ./gradlew publishToMavenCentral 2>&1 | tee /tmp/publish.log
-        exit_code=${PIPESTATUS[0]}
-        set -e
+        for attempt in 1 2 3; do
+          if ./gradlew publishToMavenCentral 2>&1 | tee /tmp/publish.log; then
+            exit 0
+          fi
 
-        if [ "$exit_code" -ne 0 ]; then
-          # Tolerate Sonatype duplicate-version rejection on retries; other failures still surface.
           if grep -q "Component with package url.*already exists" /tmp/publish.log; then
             echo "::warning::Already published to Maven Central; skipping."
             exit 0
           fi
-          exit "$exit_code"
-        fi
+
+          if [ "$attempt" -lt 3 ] && grep -q "Received status code 403 from server" /tmp/publish.log; then
+            echo "::warning::Sonatype throttled the publish (403), retrying (attempt ${attempt}/3)."
+            sleep $(( attempt * 60 + RANDOM % 60 ))
+            continue
+          fi
+
+          exit 1
+        done


### PR DESCRIPTION
Added retry to the Maven Central publish: up to 3 attempts with backoff when Sonatype throttles with 403.