### PR TITLE
feat(docker): migrate plugin install to kestractl with kestra-base images

### DIFF
--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -19,6 +19,9 @@ on:
       GH_BOT_PRIVATE_KEY:
         description: "GitHub App private key."
         required: true
+      GCP_SERVICE_ACCOUNT:
+        description: "GCP service account key JSON for Maven mirror authentication."
+        required: false
     inputs:
       retag-latest:
         description: 'Retag latest Docker images'
@@ -50,6 +53,11 @@ on:
         required: false
         type: boolean
         default: true
+      use-kestra-base-images:
+        description: 'Use kestra-base images and kestractl for plugin download. Default false preserves backward compatibility with older release branches (v0.22–v1.3).'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   plugins:
@@ -148,7 +156,7 @@ jobs:
           fi
 
           if [[ "${{ inputs.plugin-version }}" == *"-SNAPSHOT" ]]; then
-            echo "plugins=--repositories=https://central.sonatype.com/repository/maven-snapshots/ ${{ matrix.image.plugins }}" >> $GITHUB_OUTPUT;
+            echo "plugins=--repositories=https://central.sonatype.com/repository/maven-snapshots/ ${{ matrix.image.plugins }}" >> $GITHUB_OUTPUT
           else
             echo "plugins=${{ matrix.image.plugins }}" >> $GITHUB_OUTPUT
           fi
@@ -163,6 +171,37 @@ jobs:
       - name: Copy exe to image
         run: |
           cp build/executable/* docker/app/kestra && chmod +x docker/app/kestra
+
+      # Plugins
+      - name: Authenticate to Google Cloud
+        if: ${{ inputs.use-kestra-base-images && matrix.image.plugins != '' }}
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Install kestractl
+        if: ${{ inputs.use-kestra-base-images && matrix.image.plugins != '' }}
+        run: curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash
+
+      - name: Download Kestra plugins
+        if: ${{ inputs.use-kestra-base-images && matrix.image.plugins != '' }}
+        run: |
+          if [[ "${{ inputs.plugin-version }}" == *"-SNAPSHOT" ]]; then
+            MAVEN_REPOSITORY="https://central.sonatype.com/repository/maven-snapshots/"
+          else
+            MAVEN_REPOSITORY="https://europe-maven.pkg.dev/kestra-host/maven-remote"
+          fi
+          kestractl plugins download ${{ github.ref_name }} \
+            --maven-repository "$MAVEN_REPOSITORY" \
+            --maven-username oauth2accesstoken \
+            --maven-password "$(gcloud auth print-access-token)" \
+            --plugins-dir ./plugins \
+            --plugins "${{ matrix.image.plugins }}" \
+            --concurrency 10
+
+      - name: Create empty plugins dir
+        if: ${{ inputs.use-kestra-base-images && matrix.image.plugins == '' }}
+        run: mkdir -p plugins
 
       # Docker setup
       - name: Docker init
@@ -186,7 +225,7 @@ jobs:
           cache-from: type=gha,scope=docker${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=docker${{ matrix.image.name }}
           build-args: |
-            KESTRA_PLUGINS=${{ steps.vars.outputs.plugins }}
+            KESTRA_PLUGINS=${{ !inputs.use-kestra-base-images && steps.vars.outputs.plugins || '' }}
             APT_PACKAGES=${{ matrix.image.packages }}
             PYTHON_LIBRARIES=${{ matrix.image.python-libs }}
 
@@ -218,7 +257,7 @@ jobs:
             echo "validation error, $TAG did not match acceptable 'latest' regex"
             exit 1
           fi
-          
+
           regctl image copy ${{ format('kestra/kestra:{0}{1}', steps.vars.outputs.tag, matrix.image.name) }} ${{ format('kestra/kestra:latest-lts{0}', matrix.image.name) }}
 
   end:


### PR DESCRIPTION
## Summary

Replaces in-Dockerfile `/app/kestra plugins install` with a CI-side `kestractl plugins download` step for both OSS and EE images.

Adds `use-kestra-base-images` input (default `false`) — **old release branches call `@main` without this flag and are completely unaffected**.

### OSS (`kestra-oss-publish-docker.yml`)
- When `true`: downloads all plugins from GCP Maven Central mirror (`europe-maven.pkg.dev/kestra-host/maven-remote`) via kestractl, then `COPY`s them in
- When `false`: existing `KESTRA_PLUGINS` build-arg path unchanged

### EE (`kestra-ee-publish-docker.yml`)
- When `true`: two kestractl passes into the same `kestra-ee/plugins/` dir:
  1. EE plugins (`--edition EE`) from private GCP Maven repo (`europe-west1-maven.pkg.dev/kestra-host/maven`)
  2. OSS plugins (`--edition OSS`) from Maven Central mirror
  Both use the existing `glogin` access token (GCP auth stays unconditional)
- When `false`: existing `KESTRA_PLUGINS` + private repo build-arg path unchanged

## Merge order

1. Merge this PR → `@main`
2. Merge [kestra-io/kestra#16568](https://github.com/kestra-io/kestra/pull/16568) (OSS Dockerfile + main-build.yml)
3. Merge [kestra-io/kestra-ee#8359](https://github.com/kestra-io/kestra-ee/pull/8359) (EE Dockerfile + main-build.yml)

## Test plan

- [x] OSS CI triggered on `feat/base-image-ci-plugin-download` with `use-kestra-base-images: true` — 190 OSS plugins downloaded and COPYed
- [x] EE local build: 223 plugins (33 EE + 190 OSS) downloaded via two kestractl passes, Docker build succeeds
- [x] `PURE_PYTHON=1` fix — `amazon-ion` installs without Cython under QEMU
- [ ] Verify old OSS release branches (`releases/v1.3.x`) still publish with default `false`
- [ ] Verify old EE release branches still publish with default `false`