### PR TITLE
fix(ci): harden Sonatype 403 publish retry with more attempts and exponential backoff

### DIFF
--- a/composite/publish-java/action.yml
+++ b/composite/publish-java/action.yml
@@ -63,7 +63,8 @@ runs:
         echo "signing.secretKeyRingFile=${HOME}/.gradle/secring.gpg" >> ~/.gradle/gradle.properties
         echo ${SONATYPE_GPG_FILE} | base64 -d > ~/.gradle/secring.gpg
 
-        for attempt in 1 2 3; do
+        max_attempts=5
+        for attempt in $(seq 1 "$max_attempts"); do
           if ./gradlew publishToMavenCentral 2>&1 | tee /tmp/publish.log; then
             exit 0
           fi
@@ -73,9 +74,12 @@ runs:
             exit 0
           fi
 
-          if [ "$attempt" -lt 3 ] && grep -q "Received status code 403 from server" /tmp/publish.log; then
-            echo "::warning::Sonatype throttled the publish (403), retrying (attempt ${attempt}/3)."
-            sleep $(( attempt * 60 + RANDOM % 60 ))
+          if [ "$attempt" -lt "$max_attempts" ] && grep -q "Received status code 403 from server" /tmp/publish.log; then
+            # Sonatype Central Portal throttles snapshot/metadata requests under load and
+            # returns 403; back off exponentially with jitter to outlast the throttle window.
+            backoff=$(( (2 ** attempt) * 30 + RANDOM % 30 ))
+            echo "::warning::Sonatype throttled the publish (403), retrying in ${backoff}s (attempt ${attempt}/${max_attempts})."
+            sleep "$backoff"
             continue
           fi
 


### PR DESCRIPTION
## What

Hardens the snapshot/release publish retry in `composite/publish-java/action.yml`:

- Retries bumped **3 → 5** attempts (via a `max_attempts` variable, reused in the retry guard and the warning message).
- Backoff changed from `attempt * 60 + jitter` (~3 min total) to **exponential** `(2 ** attempt) * 30 + jitter` → ~60s, 150s, 300s, 540s between attempts (~17 min total retry window).

## Why

Snapshot publishes to the Sonatype Central Portal intermittently fail with a `403 Forbidden` on the `maven-metadata.xml` **read**, when the portal throttles under load (many plugins publish on every push to `main`). Example: https://github.com/kestra-io/plugin-kubernetes/actions/runs/26997545241/job/79670351165

```
> Could not GET 'https://central.sonatype.com/repository/maven-snapshots/io/kestra/plugin/plugin-kubernetes/1.9.2-SNAPSHOT/maven-metadata.xml'. Received status code 403 from server: Forbidden
```

The existing retry already targets this 403, but all 3 attempts (~3 min total) hit the same throttle window. A longer, exponential window lets the publish outlast the throttle. This affects multiple plugin repos since the logic is shared here.

## Scope

This is the throttle-resilience mitigation only. It will **not** help if a 403 is ever a genuine credential/permission problem — that would need separate handling (non-blocking snapshot publish, token/namespace verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)