### PR TITLE
fix(ci): catch HTML 403 response from Sonatype in publish retry

### DIFF
--- a/composite/publish-java/action.yml
+++ b/composite/publish-java/action.yml
@@ -74,7 +74,7 @@ runs:
             exit 0
           fi
 
-          if [ "$attempt" -lt "$max_attempts" ] && grep -q "Received status code 403 from server" /tmp/publish.log; then
+          if [ "$attempt" -lt "$max_attempts" ] && grep -qE "Received status code 403|403 Forbidden" /tmp/publish.log; then
             # Sonatype Central Portal throttles snapshot/metadata requests under load and
             # returns 403; back off exponentially with jitter to outlast the throttle window.
             backoff=$(( (2 ** attempt) * 30 + RANDOM % 30 ))


### PR DESCRIPTION
## Summary

- The Sonatype publish retry logic grepped for `"Received status code 403 from server"` (Java HTTP client wording), but Sonatype returned a raw nginx HTML `403 Forbidden` page in this run: https://github.com/kestra-io/plugin-fivetran/actions/runs/27012825143/job/79720377857
- The grep never matched, so `exit 1` fired immediately without retrying
- Broaden the pattern to `grep -qE "Received status code 403 |403 Forbidden"` to cover both response shapes

## Test plan

- [ ] Verify the next Sonatype 403 (HTML or Java-style) triggers the exponential backoff retry instead of failing immediately