### PR TITLE
chore(after-release): rename TAG_DOCS/TAG_BLUEPRINTS to BRANCH_DOCS/BRANCH_BLUEPRINTS

### DIFF
--- a/composite/after-release/global/action.yml
+++ b/composite/after-release/global/action.yml
@@ -43,8 +43,8 @@ runs:
         
         DEFAULT_TO_RELEASE_FOR_MINOR='[
           "API",
-          "TAG_DOCS",
-          "TAG_BLUEPRINTS",
+          "BRANCH_DOCS",
+          "BRANCH_BLUEPRINTS",
           "HELM_CHARTS",
           "LIBS"
         ]'


### PR DESCRIPTION
Docs/blueprints create release branches now, not tags (kestra-io/kestra-ee#7397), so the `TO_RELEASE` values in `composite/after-release/global/action.yml` are renamed for accuracy.

⚠️ **Lockstep with kestra-io/flows-engineering#46** — this composite *produces* these strings (POSTed to the `after-release-ee` flow via `AFTER_RELEASE_EE_WEBHOOK`); that flow *consumes* them via `contains` checks. This composite goes live instantly via `@main`; the flow goes live only after a manual `terraform apply`. Merge this **and** apply the flows-engineering rename together — if they diverge, docs/blueprints dispatch is silently skipped at the next release. No release should fire in the window.