### PR TITLE
feat(docker): add EE publish workflow kestractl migration and fix auth@v3

### DIFF
--- a/.github/workflows/kestra-ee-publish-docker.yml
+++ b/.github/workflows/kestra-ee-publish-docker.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: boolean
         default: true
+      use-kestra-base-images:
+        description: 'Use kestra-base images and kestractl for plugin download. Default false preserves backward compatibility with older EE release branches.'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   plugins:
@@ -185,6 +190,37 @@ jobs:
             echo "plugins=$PRIVATE_REPO ${{ matrix.image.plugins }}" >> $GITHUB_OUTPUT
           fi
 
+      # Plugins — new path (use-kestra-base-images: true)
+      - name: Install kestractl
+        if: ${{ inputs.use-kestra-base-images && matrix.image.plugins != '' }}
+        run: curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash
+
+      - name: Download EE plugins
+        if: ${{ inputs.use-kestra-base-images && matrix.image.plugins != '' }}
+        run: |
+          kestractl plugins download ${{ github.ref_name }} \
+            --edition EE \
+            --maven-repository "https://europe-west1-maven.pkg.dev/kestra-host/maven" \
+            --maven-username oauth2accesstoken \
+            --maven-password "${{ steps.glogin.outputs.access_token }}" \
+            --plugins-dir kestra-ee/plugins \
+            --concurrency 50
+
+      - name: Download OSS plugins
+        if: ${{ inputs.use-kestra-base-images && matrix.image.plugins != '' }}
+        run: |
+          kestractl plugins download ${{ github.ref_name }} \
+            --edition OSS \
+            --maven-repository "https://europe-maven.pkg.dev/kestra-host/maven-remote" \
+            --maven-username oauth2accesstoken \
+            --maven-password "${{ steps.glogin.outputs.access_token }}" \
+            --plugins-dir kestra-ee/plugins \
+            --concurrency 50
+
+      - name: Create empty plugins dir
+        if: ${{ inputs.use-kestra-base-images && matrix.image.plugins == '' }}
+        run: mkdir -p kestra-ee/plugins
+
       # Download executable from artifact
       - name: Artifacts - Download executable
         uses: actions/download-artifact@v5
@@ -232,7 +268,7 @@ jobs:
           cache-from: type=gha,scope=docker${{ matrix.image.tag }}
           cache-to: type=gha,mode=max,scope=docker${{ matrix.image.tag }}
           build-args: |
-            KESTRA_PLUGINS=${{ steps.vars.outputs.plugins }}
+            KESTRA_PLUGINS=${{ !inputs.use-kestra-base-images && steps.vars.outputs.plugins || '' }}
             APT_PACKAGES=${{ matrix.image.packages }}
             PYTHON_LIBRARIES=${{ matrix.image.python-libraries }}
 

--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -175,7 +175,7 @@ jobs:
       # Plugins
       - name: Authenticate to Google Cloud
         if: ${{ inputs.use-kestra-base-images && matrix.image.plugins != '' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
@@ -197,7 +197,7 @@ jobs:
             --maven-password "$(gcloud auth print-access-token)" \
             --plugins-dir ./plugins \
             --plugins "${{ matrix.image.plugins }}" \
-            --concurrency 30
+            --concurrency 50
 
       - name: Create empty plugins dir
         if: ${{ inputs.use-kestra-base-images && matrix.image.plugins == '' }}


### PR DESCRIPTION
## Summary

- Add `use-kestra-base-images` input to `kestra-ee-publish-docker.yml`: two-pass kestractl download (EE plugins from private GCP Maven repo, then OSS plugins from GCP Maven mirror) into `kestra-ee/plugins/` before the Docker build
- Suppress `KESTRA_PLUGINS` build-arg when `use-kestra-base-images: true` — GCP OAuth token no longer baked into image layers (fixes the token leak visible in `docker history --no-trunc` on current EE images)
- Fix `google-github-actions/auth@v2` → `@v3` in OSS publish workflow for consistency

## Merge order

This PR must be merged before [kestra-ee#8359](https://github.com/kestra-io/kestra-ee/pull/8359) since that PR sets `use-kestra-base-images: true` in `main-build.yml` pointing to `@main`.