### PR TITLE
fix(docker): add kestractl install dir to PATH in EE publish workflow

### DIFF
--- a/.github/workflows/kestra-ee-publish-docker.yml
+++ b/.github/workflows/kestra-ee-publish-docker.yml
@@ -193,7 +193,9 @@ jobs:
       # Plugins — new path (use-kestra-base-images: true)
       - name: Install kestractl
         if: ${{ inputs.use-kestra-base-images && matrix.image.plugins != '' }}
-        run: curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Download EE plugins
         if: ${{ inputs.use-kestra-base-images && matrix.image.plugins != '' }}


### PR DESCRIPTION
## Summary

- On `kestra-private-standard` runners, `/usr/local/bin` is not writable by the runner user, so the kestractl install script falls back to `~/.local/bin`
- `~/.local/bin` is not on the default `$PATH` in GitHub Actions, causing `kestractl: command not found` in the Download EE/OSS plugins steps
- Fix: append `$HOME/.local/bin` to `$GITHUB_PATH` after the install — this is a no-op when kestractl landed in `/usr/local/bin` (ubuntu-latest) and fixes the issue on private runners

## Test plan

- [ ] Verify the EE `publish-develop-docker` job completes past the plugin download steps
- [ ] Confirm OSS workflow is unaffected (it uses `ubuntu-latest` where `/usr/local/bin` is writable — this change is safe there too)