### PR TITLE
fix(ci): conditionally pass --plugins flag to kestractl download

### DIFF
--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -201,7 +201,6 @@ jobs:
             --maven-username oauth2accesstoken \
             --maven-password "$(gcloud auth print-access-token)" \
             --plugins-dir ./plugins \
-            --plugins "${{ matrix.image.plugins }}" \
             --concurrency 50
 
       - name: Create empty plugins dir


### PR DESCRIPTION
## Summary

- When `use-kestra-base-images=true` the `plugins` job is skipped, so `matrix.image.plugins` is empty
- Passing `--plugins ""` caused kestractl to fail: `Error: --plugins was set but no valid coordinates were found`
- Fix: only pass `--plugins` when the value is non-empty — old CI callers that supply an explicit plugin list via `plugin-version` are unaffected

## Test plan

- [ ] Trigger `kestra-oss-publish-docker` with `use-kestra-base-images: true` — plugin download step should succeed without `--plugins` flag
- [ ] Old release branches passing `plugin-version` still work (flag is passed when non-empty)