### PR TITLE
fix(ci): always run plugins job regardless of use-kestra-base-images

### DIFF
--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -63,7 +63,6 @@ jobs:
   plugins:
     name: List Plugins
     runs-on: ubuntu-latest
-    if: ${{ !inputs.use-kestra-base-images }}
     outputs:
       plugins: ${{ steps.plugins-outputs-step.outputs.plugins }}
     steps:

--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -185,7 +185,9 @@ jobs:
 
       - name: Install kestractl
         if: ${{ inputs.use-kestra-base-images && matrix.image.name != '-no-plugins' }}
-        run: curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Download Kestra plugins
         if: ${{ inputs.use-kestra-base-images && matrix.image.name != '-no-plugins' }}


### PR DESCRIPTION
## Summary

- The `plugins` job was gated with `if: ${{ !inputs.use-kestra-base-images }}`, so when `use-kestra-base-images: true` the job was skipped
- This left `matrix.image.plugins` empty, causing kestractl to fail: `Error: --plugins was set but no valid coordinates were found`
- Fix: remove the condition so the plugins job always runs and populates the plugin list for both paths

## Test plan

- [ ] Trigger `kestra-oss-publish-docker` with `use-kestra-base-images: true` — plugins job runs, kestractl receives `--plugins <list>` and succeeds
- [ ] Trigger with `use-kestra-base-images: false` — unchanged behavior