### PR TITLE
fix(ci): dump 403 response headers for Sonatype WAF diagnostic

### DIFF
--- a/composite/publish-java/action.yml
+++ b/composite/publish-java/action.yml
@@ -75,6 +75,13 @@ runs:
           fi
 
           if [ "$attempt" -lt "$max_attempts" ] && grep -qE "Received status code 403|403 Forbidden" /tmp/publish.log; then
+            # Dump response headers so Sonatype support can identify which WAF layer blocked the request.
+            failed_url=$(grep -oP "(?<=Could not GET ')[^']+" /tmp/publish.log | head -1)
+            if [ -n "$failed_url" ]; then
+              echo "=== 403 response headers (Sonatype diagnostic) ==="
+              curl -sv -u "${ORG_GRADLE_PROJECT_mavenCentralUsername}:${ORG_GRADLE_PROJECT_mavenCentralPassword}" \
+                -o /dev/null "$failed_url" 2>&1 | grep -E "^[<>*]"
+            fi
             # Sonatype Central Portal throttles snapshot/metadata requests under load and
             # returns 403; back off exponentially with jitter to outlast the throttle window.
             backoff=$(( (2 ** attempt) * 30 + RANDOM % 30 ))


### PR DESCRIPTION
## Summary

Sonatype support asked for HTTP response headers from the 403 errors to identify which WAF layer is blocking publishing from GitHub Actions runners (see kestra-io/kestra-ee#6311).

When a 403 is detected in the `publishToMavenCentral` retry loop, extract the failing URL from the Gradle log and curl it with `-sv` to print the raw response headers before the backoff retry:

```bash
failed_url=$(grep -oP "(?<=Could not GET ')[^']+" /tmp/publish.log | head -1)
if [ -n "$failed_url" ]; then
  echo "=== 403 response headers (Sonatype diagnostic) ==="
  curl -sv -u "${ORG_GRADLE_PROJECT_mavenCentralUsername}:${ORG_GRADLE_PROJECT_mavenCentralPassword}" \
    -o /dev/null "$failed_url" 2>&1 | grep -E "^[<>*]"
fi
```

The URL is already present in the existing Gradle log (`Could not GET 'URL'. Received status code 403`), so no change to the Gradle invocation is needed. Headers like `Server:`, `CF-Ray:`, `X-Cache:` will tell Sonatype whether the block originates from the CDN, WAF, or application layer.

Part-of kestra-io/kestra-ee#6311
