### PR TITLE
fix(docker): remove GHA cache from EE Docker publish

### DIFF
--- a/.github/workflows/kestra-ee-publish-docker.yml
+++ b/.github/workflows/kestra-ee-publish-docker.yml
@@ -267,8 +267,6 @@ jobs:
             ${{ env.GCP_IMAGE_PATH }}:${{ steps.vars.outputs.tag }}
           platforms: linux/amd64,linux/arm64
           network: host
-          cache-from: type=gha,scope=docker${{ matrix.image.tag }}
-          cache-to: type=gha,mode=max,scope=docker${{ matrix.image.tag }}
           build-args: |
             KESTRA_PLUGINS=${{ !inputs.use-kestra-base-images && steps.vars.outputs.plugins || '' }}
             APT_PACKAGES=${{ matrix.image.packages }}
@@ -291,7 +289,6 @@ jobs:
           tags: ${{ env.CLOUD_GCP_IMAGE_PATH }}:${{ steps.vars.outputs.tag }}
           platforms: linux/amd64,linux/arm64
           network: host
-          cache-from: type=gha,scope=docker${{ matrix.image.tag }}
           build-args: |
             BASE_IMAGE=${{ env.GITHUB_IMAGE_PATH }}:${{ steps.vars.outputs.tag }}
 


### PR DESCRIPTION
## Summary

- GHA cache (`cache-from/cache-to: type=gha`) was costing **14+ minutes** per develop Docker publish build
- Root cause: `#16 exporting to GitHub Actions Cache: 855s` — writing ~3.5GB of plugin layers to GHA cache with **0% cache hit rate**
- The kestra binary (from the build artifact) and the 223 plugin JARs both change on every commit, so layers never match the cache
- The actual Docker build + push to ghcr.io + GCP Artifact Registry takes only ~191s (~3.2 min)

## Expected result

Develop Docker publish: **~18.7 min → ~5 min** for the full-plugins variant.

## What was removed

- `cache-from: type=gha,scope=docker${{ matrix.image.tag }}` from main build step
- `cache-to: type=gha,mode=max,scope=docker${{ matrix.image.tag }}` from main build step
- `cache-from: type=gha,scope=docker${{ matrix.image.tag }}` from Cloud build step