### PR TITLE
feat(helm): add centralized OSS helm-release reusable workflow

### DIFF
--- a/.github/workflows/kestra-oss-helm-release.yml
+++ b/.github/workflows/kestra-oss-helm-release.yml
@@ -1,0 +1,182 @@
+name: Publish Helm charts (OSS)
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Kestra version to release (e.g. 1.3.22, without v prefix). If omitted, inferred from GITHUB_REF_NAME.'
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        description: 'Dry run — package charts but do not upload to GCS'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  helm-release:
+    name: Package and publish Helm charts
+    runs-on: ubuntu-latest
+    env:
+      BUCKET: helm-charts-kestra-host
+      REPO_URL: https://helm.kestra.io/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.12.3
+
+      - name: Install kubeconform and helm-docs
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/kc.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kc.tar.gz -C /usr/local/bin kubeconform
+          curl -fsSL -o /tmp/hd.tar.gz \
+            https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz
+          tar -xzf /tmp/hd.tar.gz -C /usr/local/bin helm-docs
+
+      - name: Verify helm-docs are up to date
+        run: helm-docs
+
+      - name: Fail on uncommitted README diffs
+        run: git diff --exit-code -- 'charts/**/README.md'
+
+      - name: Resolve version and dry-run flag
+        id: config
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+            TAG="v${VERSION}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+            VERSION="${TAG#v}"
+          fi
+          DRY_RUN="${{ inputs.dry_run }}"
+          echo "tag=${TAG}"        >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "dry_run=${DRY_RUN}" >> $GITHUB_OUTPUT
+          echo "Version: ${VERSION} | Tag: ${TAG} | Dry run: ${DRY_RUN}"
+
+      - name: Update Chart.yaml versions
+        env:
+          VERSION: ${{ steps.config.outputs.version }}
+          TAG: ${{ steps.config.outputs.tag }}
+        run: |
+          set -euo pipefail
+          for chart in charts/kestra charts/kestra-starter; do
+            sed -i "s/^version:.*/version: \"${VERSION}\"/" ${chart}/Chart.yaml
+            sed -i "s/^appVersion:.*/appVersion: \"${TAG}\"/" ${chart}/Chart.yaml
+          done
+          # Update kestra dep version in kestra-starter
+          awk -v ver="${VERSION}" '
+            /- name: kestra/ { found=1 }
+            found && /version:/ { sub(/version:.*/, "version: \"" ver "\""); found=0 }
+            { print }
+          ' charts/kestra-starter/Chart.yaml > /tmp/chart-starter.yaml
+          mv /tmp/chart-starter.yaml charts/kestra-starter/Chart.yaml
+
+      - name: Regenerate helm-docs after version bump
+        run: helm-docs
+
+      - name: Lint kestra chart
+        run: |
+          helm lint charts/kestra \
+            --set "configurations.application=kestra.variable.globals.foo: bar"
+
+      - name: Package kestra chart
+        run: |
+          mkdir -p release/
+          helm package charts/kestra -d release/
+
+      - name: Bundle kestra as kestra-starter dependency
+        env:
+          VERSION: ${{ steps.config.outputs.version }}
+        run: |
+          helm repo add groundhog2k https://groundhog2k.github.io/helm-charts/
+          helm repo update groundhog2k
+          mkdir -p charts/kestra-starter/charts/
+          cp release/kestra-${VERSION}.tgz charts/kestra-starter/charts/
+          POSTGRES_VER=$(awk '/- name: postgres/{found=1} found && /version:/{gsub(/"/, ""); print $2; exit}' charts/kestra-starter/Chart.yaml)
+          helm pull groundhog2k/postgres --version "${POSTGRES_VER}" -d charts/kestra-starter/charts/
+          rm -f charts/kestra-starter/Chart.lock
+
+      - name: Lint kestra-starter chart
+        run: helm lint charts/kestra-starter
+
+      - name: Package kestra-starter chart
+        run: helm package charts/kestra-starter -d release/
+
+      - name: Verify packaged charts with kubeconform
+        env:
+          VERSION: ${{ steps.config.outputs.version }}
+        run: |
+          set -euo pipefail
+          helm template test release/kestra-${VERSION}.tgz \
+            --set "configurations.application=kestra.variable.globals.foo: bar" \
+            --validate=false \
+            | kubeconform -strict -summary
+          echo "kestra-${VERSION}.tgz validates OK"
+          helm template test release/kestra-starter-${VERSION}.tgz --validate=false \
+            | kubeconform -strict -summary
+          echo "kestra-starter-${VERSION}.tgz validates OK"
+
+      - name: Verify Docker Hub has appVersion image
+        env:
+          TAG: ${{ steps.config.outputs.tag }}
+        run: |
+          set -euo pipefail
+          STATUS=$(curl -fsS -o /dev/null -w "%{http_code}" \
+            "https://hub.docker.com/v2/repositories/kestra/kestra/tags/${TAG}/" || true)
+          if [[ "${STATUS}" != "200" ]]; then
+            echo "::error::Docker Hub tag kestra/kestra:${TAG} not found (HTTP ${STATUS}). Refusing to publish chart for an image that doesn't exist."
+            exit 1
+          fi
+          echo "Docker Hub tag kestra/kestra:${TAG} exists — safe to publish chart."
+
+      - name: Show packaged charts
+        run: ls -lh release/*.tgz
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/230725787862/locations/global/workloadIdentityPools/github/providers/github
+          service_account: helm-charts-publisher@kestra-host.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - name: Download existing index.yaml from GCS
+        run: gsutil cp gs://${BUCKET}/index.yaml existing-index.yaml
+
+      - name: Generate merged index.yaml
+        run: |
+          helm repo index release/ --merge existing-index.yaml --url ${REPO_URL}
+          echo "=== Preview (first 30 lines) ==="
+          head -30 release/index.yaml
+
+      - name: Dry run — show what would be uploaded
+        if: ${{ steps.config.outputs.dry_run == 'true' }}
+        run: |
+          echo "DRY RUN — no upload performed."
+          echo ""
+          echo "Would upload to gs://${BUCKET}/:"
+          ls -lh release/*.tgz release/index.yaml
+
+      - name: Upload to GCS
+        if: ${{ steps.config.outputs.dry_run == 'false' }}
+        run: |
+          set -euo pipefail
+          # Upload .tgz files first — index must never reference a missing artifact
+          gsutil -m cp release/*.tgz gs://${BUCKET}/
+          gsutil cp release/index.yaml gs://${BUCKET}/index.yaml
+          echo "Published:"
+          ls -lh release/*.tgz

--- a/.github/workflows/kestra-oss-helm-release.yml
+++ b/.github/workflows/kestra-oss-helm-release.yml
@@ -1,6 +1,17 @@
 name: Publish Helm charts (OSS)
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Kestra version to release (e.g. 1.3.22, without v prefix)'
+        required: true
+        type: string
+      dry-run:
+        description: 'Dry run — package charts but do not upload to GCS'
+        required: true
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       version:
@@ -27,8 +38,11 @@ jobs:
       REPO_URL: https://helm.kestra.io/
 
     steps:
-      - name: Checkout
+      - name: Checkout kestra
         uses: actions/checkout@v6
+        with:
+          repository: kestra-io/kestra
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'develop' || github.ref }}
 
       - name: Setup Helm
         uses: azure/setup-helm@v5

--- a/.github/workflows/kestra-oss-helm-release.yml
+++ b/.github/workflows/kestra-oss-helm-release.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
         default: ''
-      dry_run:
+      dry-run:
         description: 'Dry run — package charts but do not upload to GCS'
         required: false
         type: boolean
@@ -61,7 +61,7 @@ jobs:
             TAG="${GITHUB_REF_NAME}"
             VERSION="${TAG#v}"
           fi
-          DRY_RUN="${{ inputs.dry_run }}"
+          DRY_RUN="${{ inputs.dry-run }}"
           echo "tag=${TAG}"        >> $GITHUB_OUTPUT
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "dry_run=${DRY_RUN}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Adds `kestra-oss-helm-release.yml` as a centralized reusable workflow supporting both `workflow_call` (automated releases) and `workflow_dispatch` (manual helm-only releases)
- Checkout always targets `kestra-io/kestra` explicitly: `develop` for manual dispatch, caller's ref (the release tag) for automated `workflow_call`
- All helm packaging logic lives here at `@main` — callers never freeze it at an old release tag

## Context

`helm-release.yml` previously lived inside `kestra-io/kestra`. When `release-docker.yml` called it via `uses: ./.github/workflows/helm-release.yml`, GitHub resolved the workflow file at the **caller's ref** (e.g. `refs/tags/v1.3.22`). Release branches carried an older version of the workflow that skipped the `helm-docs` regeneration step after bumping `Chart.yaml`. Result: every published chart tarball shipped a `README.md` still showing the stale version from the release branch (e.g. `kestra-1.3.22.tgz` showed `Version: 1.0.53`), which ArtifactHub rendered verbatim.

Centralizing here and having callers use `@main` ensures the packaging logic — including `helm-docs` regeneration — is always current regardless of which tag triggers the release.

## Usage

**Automated release** (called from `kestra-io/kestra` `release-docker.yml`):
```yaml
uses: kestra-io/actions/.github/workflows/kestra-oss-helm-release.yml@main
with:
  dry-run: false
# version inferred from GITHUB_REF_NAME (the release tag)
```

**Manual helm-only release** (dispatched from this repo's Actions tab):
- `version`: the Kestra version to release, e.g. `1.3.22`
- `dry-run`: defaults to `true` — set to `false` to actually publish

Closes #128