### PR TITLE
fix(docker): support v2+ tags in retag-latest and retag-lts steps

### DIFF
--- a/.github/workflows/kestra-ee-publish-docker.yml
+++ b/.github/workflows/kestra-ee-publish-docker.yml
@@ -306,7 +306,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') && (inputs.retag-latest == true || inputs.retag-latest == 'true') && (inputs.dry-run == false)
         run: |
           TAG=${GITHUB_REF#refs/*/}
-          if [[ ! $TAG =~ ^v1\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "validation error, $TAG did not match acceptable 'latest' regex"
             exit 1
           fi
@@ -319,7 +319,7 @@ jobs:
         run: |
           echo "TODO remove this safety net after debugging inputs.retag-lts, its value: ${{ inputs.retag-lts }}"
           TAG=${GITHUB_REF#refs/*/}
-          if [[ ! $TAG =~ ^v1\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "validation error, $TAG did not match acceptable 'latest' regex"
             exit 1
           fi

--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -249,7 +249,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') && (inputs.retag-latest == true || inputs.retag-latest == 'true')  && (inputs.dry-run == false)
         run: |
           TAG=${GITHUB_REF#refs/*/}
-          if [[ ! $TAG =~ ^v1\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "validation error, $TAG did not match acceptable 'latest' regex"
             exit 1
           fi
@@ -260,7 +260,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') && (inputs.retag-lts == true || inputs.retag-lts == 'true') && (inputs.dry-run == false)
         run: |
           TAG=${GITHUB_REF#refs/*/}
-          if [[ ! $TAG =~ ^v1\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "validation error, $TAG did not match acceptable 'latest' regex"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- `kestra-oss-publish-docker.yml` and `kestra-ee-publish-docker.yml` both guarded the **Retag to latest** and **Retag to LTS** steps with `^v1\.[0-9]+\.[0-9]+$`
- This regex hardcodes the `v1` major version — triggering `retag-latest` or `retag-lts` on a `v2.0.0` tag would have failed with `"validation error, $TAG did not match acceptable 'latest' regex"`
- Fix: generalize to `^v[0-9]+\.[0-9]+\.[0-9]+$` — accepts any `vMAJOR.MINOR.PATCH` tag

## Files changed

- `.github/workflows/kestra-oss-publish-docker.yml` — 2 occurrences
- `.github/workflows/kestra-ee-publish-docker.yml` — 2 occurrences

## Test plan

- [ ] Verify a dry-run dispatch with a `v2.0.0`-style tag does not hit the guard
- [ ] Confirm `v1.x.x` tags still pass (regex is additive, not restrictive)