### PR TITLE
ci: add 90m timeout to OSS backend test job

### DIFF
--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -37,7 +37,7 @@ jobs:
   check:
     name: Check
     runs-on: kestra-private-large
-    timeout-minutes: 120
+    timeout-minutes: 90
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}

--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -37,7 +37,7 @@ jobs:
   check:
     name: Check
     runs-on: kestra-private-large
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}

--- a/.github/workflows/kestra-oss-backend-tests.yml
+++ b/.github/workflows/kestra-oss-backend-tests.yml
@@ -37,7 +37,7 @@ jobs:
   test:
     name: Backend - Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 90
     env:
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/kestra-oss-backend-tests.yml
+++ b/.github/workflows/kestra-oss-backend-tests.yml
@@ -37,6 +37,7 @@ jobs:
   test:
     name: Backend - Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     env:
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## What

Add a 90 minute (`timeout-minutes: 90`) timeout to the OSS backend `test` job (`kestra-oss-backend-tests.yml`), which previously had no timeout.

The EE backend `check` job (`kestra-ee-backend-tests.yml`) already had `timeout-minutes: 90`, so it is unchanged.

## Why

Prevents hung backend test runs from holding runners indefinitely, matching the EE job's existing 90m limit.