### PR TITLE
fix(ci): route Gradle dependency reads through GCP AR maven-remote proxy

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -110,12 +110,34 @@ jobs:
         with:
           secrets: ${{ toJSON(secrets) }}
 
-      # Auth to google with github are required for com.google.cloud.artifactregistry.gradle-plugin
+      # Auth to google — required for com.google.cloud.artifactregistry.gradle-plugin (EE plugins)
+      # and to obtain an access token used by the maven-remote init script (all plugins).
       - name: GCP - Auth with github service account
+        id: gcp-auth
         uses: 'google-github-actions/auth@v3'
-        if: ${{ inputs.sonatype-publish == false }}
+        if: ${{ secrets.GCP_SERVICE_ACCOUNT != '' }}
         with:
+          token_format: 'access_token'
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      # Inject a Gradle init script that routes all Maven reads through the GCP AR maven-remote
+      # caching proxy, avoiding Maven Central 403s caused by shared GitHub Actions runner IPs.
+      # The token is passed at build time via MAVEN_REMOTE_TOKEN; the script is a no-op when empty.
+      - name: Setup - Gradle maven-remote init script
+        if: ${{ steps.gcp-auth.outputs.access_token != '' }}
+        shell: bash
+        run: |
+          mkdir -p ~/.gradle/init.d
+          cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
+          def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
+          if (token) {
+              def mavenRemote = { url "https://europe-maven.pkg.dev/kestra-host/maven-remote"; credentials { username "oauth2accesstoken"; password token } }
+              allprojects {
+                  buildscript { repositories.addFirst(maven(mavenRemote)) }
+                  repositories { addFirst(maven(mavenRemote)) }
+              }
+          }
+          EOF
 
       # Setup unit tests environment
       - name: Setup - Unit test
@@ -125,7 +147,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           if [ -f .github/setup-unit.sh ]; then
-            ./.github/setup-unit.sh 
+            ./.github/setup-unit.sh
           fi
 
       # Gradle check
@@ -134,6 +156,7 @@ jobs:
         shell: bash
         run: ./gradlew check ${{ inputs.generate-shadowjar == true && 'shadowJar' || ''  }} --parallel
         env:
+          MAVEN_REMOTE_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
           JAVA_OPTS: "-Xmx2g -XX:MaxMetaspaceSize=1g"
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary

Maven Central returns 403 for shared GitHub Actions runner IPs when the Gradle dependency cache is cold. The failure chain for OSS plugins (e.g. `plugin-ai` - [full logs](https://github.com/kestra-io/plugin-ai/actions/runs/28035033846/job/82985922960)):

```
spotless-conventions:1.1.0
  → spotless-plugin-gradle:7.0.4
    → gradle-node-plugin:7.1.0
      → jackson-databind:2.14.2  ← 403 from repo.maven.apache.org
```

Changes to `plugins.yml`:
- **GCP auth step**: now runs for all plugins when `GCP_SERVICE_ACCOUNT` is set (was `sonatype-publish == false` only); adds `token_format: access_token` so the token is available downstream
- **New init-script step**: writes `~/.gradle/init.d/maven-remote.gradle` that prepends `maven-remote` (GCP AR caching proxy of Maven Central) to both `buildscript.repositories` and project `repositories` — covers the buildscript classpath where the 403 was occurring
- **Gradle Check step**: passes `MAVEN_REMOTE_TOKEN` env var consumed by the init script

The init script is a no-op when the token is empty (forks, external contributors without `GCP_SERVICE_ACCOUNT`), so the existing fallback to Maven Central is preserved.

Companion to #121 (Docker image builds). Part-of kestra-io/kestra-ee#6311