### PR TITLE
ci: move OpenTelemetry export-trace out of reusable workflows

### DIFF
--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -104,20 +104,3 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           secrets: ${{ toJSON(secrets) }}
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry - Export Trace
-    runs-on: kestra-private-standard
-    needs: [ check ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-ee-build-artifacts.yml
+++ b/.github/workflows/kestra-ee-build-artifacts.yml
@@ -122,20 +122,3 @@ jobs:
         with:
           name: swagger
           path: swagger
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry - Export Trace
-    runs-on: kestra-private-standard
-    needs: [ build-artifacts ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-ee-e2e-tests.yml
+++ b/.github/workflows/kestra-ee-e2e-tests.yml
@@ -129,20 +129,3 @@ jobs:
           name: playwright-report
           path: kestra-ee/ui-ee/playwright-report/
           retention-days: 7
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: kestra-private-standard
-    needs: [ check ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-ee-frontend-tests.yml
+++ b/.github/workflows/kestra-ee-frontend-tests.yml
@@ -108,20 +108,3 @@ jobs:
         shell: bash
         working-directory: kestra-ee/ui-ee
         run: npm run test:storybook -- --coverage
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: kestra-private-standard
-    needs: [ check ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-ee-publish-docker.yml
+++ b/.github/workflows/kestra-ee-publish-docker.yml
@@ -358,20 +358,3 @@ jobs:
         uses: kestra-io/actions/composite/slack-status@main
         with:
           webhook-url: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: kestra-private-standard
-    needs: [ plugins, build-artifacts, docker, end ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-ee-publish-github.yml
+++ b/.github/workflows/kestra-ee-publish-github.yml
@@ -86,20 +86,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TAG: ${{ github.ref_name }}
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: kestra-private-standard
-    needs: [ release ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-ee-publish-maven.yml
+++ b/.github/workflows/kestra-ee-publish-maven.yml
@@ -81,20 +81,3 @@ jobs:
         uses: gradle/actions/dependency-submission@v4
         with:
           build-root-directory: kestra-ee
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: kestra-private-standard
-    needs: [ maven ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-ee-pullrequest-publish-docker.yml
+++ b/.github/workflows/kestra-ee-pullrequest-publish-docker.yml
@@ -107,20 +107,3 @@ jobs:
             ```bash
             docker run --pull=always --rm -it -p 8080:8080 --user=root -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp ${{ env.GITHUB_IMAGE_PATH }}:${{ github.event.pull_request.number }} server local
             ```
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: kestra-private-standard
-    needs: [ build-artifacts, docker ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-oss-backend-tests.yml
+++ b/.github/workflows/kestra-oss-backend-tests.yml
@@ -99,20 +99,3 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           secrets: ${{ toJSON(secrets) }}
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: ubuntu-latest
-    needs: [ test ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-oss-build-artifacts.yml
+++ b/.github/workflows/kestra-oss-build-artifacts.yml
@@ -78,20 +78,3 @@ jobs:
         with:
           name: exe
           path: build/executable/
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: ubuntu-latest
-    needs: [ build ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-oss-designsystem-tests.yml
+++ b/.github/workflows/kestra-oss-designsystem-tests.yml
@@ -72,20 +72,3 @@ jobs:
       - name: Run storybook component tests
         working-directory: ui/packages/design-system
         run: npm run storybook:test -- --coverage
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: ubuntu-latest
-    needs: [ test ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-oss-e2e-tests.yml
+++ b/.github/workflows/kestra-oss-e2e-tests.yml
@@ -82,20 +82,3 @@ jobs:
           name: playwright-report
           path: kestra/ui/playwright-report/
           retention-days: 7
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: ubuntu-latest
-    needs: [ check ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-oss-frontend-tests.yml
+++ b/.github/workflows/kestra-oss-frontend-tests.yml
@@ -94,20 +94,3 @@ jobs:
       - name: Run storybook component tests
         working-directory: ui
         run: npm run test:storybook -- --coverage
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: ubuntu-latest
-    needs: [ test ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-oss-helm-release.yml
+++ b/.github/workflows/kestra-oss-helm-release.yml
@@ -197,20 +197,3 @@ jobs:
           gsutil cp release/index.yaml gs://${BUCKET}/index.yaml
           echo "Published:"
           ls -lh release/*.tgz
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: ubuntu-latest
-    needs: [ helm-release ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-oss-publish-docker.yml
+++ b/.github/workflows/kestra-oss-publish-docker.yml
@@ -289,20 +289,3 @@ jobs:
         uses: kestra-io/actions/composite/slack-status@main
         with:
           webhook-url: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: ubuntu-latest
-    needs: [ plugins, build-artifacts, docker, end ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-oss-publish-github.yml
+++ b/.github/workflows/kestra-oss-publish-github.yml
@@ -78,20 +78,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TAG: ${{ github.ref_name }}
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: ubuntu-latest
-    needs: [ publish ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-oss-publish-maven.yml
+++ b/.github/workflows/kestra-oss-publish-maven.yml
@@ -85,20 +85,3 @@ jobs:
       # Gradle dependency
       - name: Java - Gradle dependency graph
         uses: gradle/actions/dependency-submission@v4
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: ubuntu-latest
-    needs: [ publish ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"

--- a/.github/workflows/kestra-oss-pullrequest-publish-docker.yml
+++ b/.github/workflows/kestra-oss-pullrequest-publish-docker.yml
@@ -97,20 +97,3 @@ jobs:
             ```bash
             docker run --pull=always --rm -it -p 8080:8080 --user=root -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp ${{ env.GITHUB_IMAGE_PATH }}:${{ github.event.pull_request.number }} server local
             ```
-
-  otel-export-trace:
-    if: always()
-    name: OpenTelemetry Export Trace
-    runs-on: ubuntu-latest
-    needs: [ build-artifacts, publish ]
-    steps:
-      - name: OpenTelemetry - Export trace
-        uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
-        with:
-          mode: export-all
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
-          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
-          logs-enabled: 'true'
-          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"


### PR DESCRIPTION
## What

Removes the `otel-export-trace` job (`mode: export-all`) from all `kestra-oss-*` / `kestra-ee-*` reusable workflows.

The per-job **`Setup - OpenTelemetry`** instrument step is kept — only the final aggregation job moves.

## Why

Reusable workflows share the **caller's** `github.run_id`. The export-all job reconstructs the whole run's trace from the GitHub API, so when a triggering workflow called several reusable workflows, each one re-exported the entire run — N duplicate exports per run.

The export now happens **once**, at the triggering-workflow level, where it can aggregate the full run correctly.

## Companion PRs

The export-all job is added to the triggering workflows in:
- kestra-io/kestra (`pull-request`, `main-build`, `pre-release`, `release-docker`, `e2e-scheduling`)
- kestra-io/kestra-ee (same five)

⚠️ These reference `actions@main`, so this PR and the two companions should land together.