### PR TITLE
fix(ci): use step output to guard GCP auth in reusable workflow

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -112,10 +112,14 @@ jobs:
 
       # Auth to google — required for com.google.cloud.artifactregistry.gradle-plugin (EE plugins)
       # and to obtain an access token used by the maven-remote init script (all plugins).
+      - name: GCP - Check credentials availability
+        id: gcp-check
+        run: echo "available=${{ secrets.GCP_SERVICE_ACCOUNT != '' }}" >> $GITHUB_OUTPUT
+
       - name: GCP - Auth with github service account
         id: gcp-auth
         uses: 'google-github-actions/auth@v3'
-        if: ${{ secrets.GCP_SERVICE_ACCOUNT != '' }}
+        if: steps.gcp-check.outputs.available == 'true'
         with:
           token_format: 'access_token'
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
## Summary

- `secrets` context is not available in `if:` expressions inside called (reusable) workflows — GitHub evaluates these at parse time before secrets resolve
- Adds a preceding `gcp-check` step that writes a boolean to `GITHUB_OUTPUT` via a `run:` step (execution-time, secrets available)
- Guards the `google-github-actions/auth` step on `steps.gcp-check.outputs.available == 'true'` instead
- Avoids the alternative (workflow-level `env` var) which would expose the secret value to all steps' process environments

Fixes the CI breakage introduced by f2ad7d4.

## Test plan

- [ ] Confirm CI passes on repos with `GCP_SERVICE_ACCOUNT` set (EE plugins)
- [ ] Confirm CI passes on repos without `GCP_SERVICE_ACCOUNT` (OSS plugins — auth step skipped)