### PR TITLE
fix(ci): fix maven() scope in buildscript block of Gradle init script

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -112,10 +112,14 @@ jobs:
 
       # Auth to google — required for com.google.cloud.artifactregistry.gradle-plugin (EE plugins)
       # and to obtain an access token used by the maven-remote init script (all plugins).
+      - name: GCP - Check credentials availability
+        id: gcp-check
+        run: echo "available=${{ secrets.GCP_SERVICE_ACCOUNT != '' }}" >> $GITHUB_OUTPUT
+
       - name: GCP - Auth with github service account
         id: gcp-auth
         uses: 'google-github-actions/auth@v3'
-        if: ${{ secrets.GCP_SERVICE_ACCOUNT != '' }}
+        if: steps.gcp-check.outputs.available == 'true'
         with:
           token_format: 'access_token'
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -137,7 +137,7 @@ jobs:
           if (token) {
               def mavenRemote = { url "https://europe-maven.pkg.dev/kestra-host/maven-remote"; credentials { username "oauth2accesstoken"; password token } }
               allprojects {
-                  buildscript { repositories.addFirst(maven(mavenRemote)) }
+                  buildscript { repositories { addFirst(maven(mavenRemote)) } }
                   repositories { addFirst(maven(mavenRemote)) }
               }
           }


### PR DESCRIPTION
## Summary

- `buildscript { repositories.addFirst(maven(mavenRemote)) }` calls `maven()` in the scope of `ScriptHandler` (the `buildscript` delegate), which doesn't have that method
- Fix: nest inside `repositories { }` so `maven()` resolves against `RepositoryHandler`
- Bug was masked by the parse error fixed in #138 — once the workflow started running, this surfaced

## Test plan

- [ ] CI passes on `plugin-debezium` (EE repo with `GCP_SERVICE_ACCOUNT` set)