### PR TITLE
fix(ci): fix maven() scope in buildscript block of Gradle init script

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -137,7 +137,7 @@ jobs:
           if (token) {
               def mavenRemote = { url "https://europe-maven.pkg.dev/kestra-host/maven-remote"; credentials { username "oauth2accesstoken"; password token } }
               allprojects {
-                  buildscript { repositories.addFirst(maven(mavenRemote)) }
+                  buildscript { repositories { addFirst(maven(mavenRemote)) } }
                   repositories { addFirst(maven(mavenRemote)) }
               }
           }


### PR DESCRIPTION
## Summary

- `buildscript { repositories.addFirst(maven(mavenRemote)) }` calls `maven()` in scope of `ScriptHandler` (the `buildscript` delegate), which doesn't have that method
- Fix: nest inside `repositories { }` so `maven()` resolves against `RepositoryHandler`
- Bug introduced in #136, masked by the parse error fixed in #138

## Test plan

- [ ] CI passes on `plugin-debezium` and `plugin-serdes` (EE repos with `GCP_SERVICE_ACCOUNT` set)