### PR TITLE
fix(ci): give GCP maven-remote repo a unique name to avoid conflict

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -135,7 +135,7 @@ jobs:
           cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
           def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
           if (token) {
-              def mavenRemote = { url "https://europe-maven.pkg.dev/kestra-host/maven-remote"; credentials { username "oauth2accesstoken"; password token } }
+              def mavenRemote = { name = "GcpMavenRemote"; url "https://europe-maven.pkg.dev/kestra-host/maven-remote"; credentials { username "oauth2accesstoken"; password token } }
               allprojects {
                   buildscript { repositories { addFirst(maven(mavenRemote)) } }
                   repositories { addFirst(maven(mavenRemote)) }


### PR DESCRIPTION
## Summary

- `maven()` in Gradle defaults to name `"maven"`, conflicting with existing repos of the same name in project build scripts
- Fix: set `name = "GcpMavenRemote"` in the closure so the repo has a unique name

Follows #140.

## Test plan

- [ ] CI passes on `plugin-debezium` and `plugin-serdes`