### PR TITLE
fix(ci): stop double-adding the GCP maven-remote repo (follow-up to #141)

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -137,8 +137,8 @@ jobs:
           if (token) {
               def mavenRemote = { name = "GcpMavenRemote"; url "https://europe-maven.pkg.dev/kestra-host/maven-remote"; credentials { username "oauth2accesstoken"; password token } }
               allprojects {
-                  buildscript { repositories { addFirst(maven(mavenRemote)) } }
-                  repositories { addFirst(maven(mavenRemote)) }
+                  buildscript { repositories { def r = maven(mavenRemote); remove(r); addFirst(r) } }
+                  repositories { def r = maven(mavenRemote); remove(r); addFirst(r) }
               }
           }
           EOF


### PR DESCRIPTION
## Summary

Follow-up to **#141**. Giving the repo a unique name was necessary but **not sufficient** — the build still fails at the init script, now with:

```
* Where: Initialization script '.../init.d/maven-remote.gradle' line: 5
* What went wrong:
Cannot add a repository with name 'GcpMavenRemote' as a repository with that name already exists.
```

**Root cause — double add.** On a `RepositoryHandler`, `maven(mavenRemote)` does not just *create* a repository; it **creates, adds, and returns** it. Wrapping that in `addFirst(...)` re-adds the *same* object → duplicate-name error. #141 only changed which name appears in the error (`maven` → `GcpMavenRemote`); the double-add remained.

## Fix

Add the repo once, then move it to the front (`def r = maven(mavenRemote); remove(r); addFirst(r)`), keeping the unique name from #141.

```diff
               def mavenRemote = { name = "GcpMavenRemote"; url "..."; credentials { ... } }
               allprojects {
-                  buildscript { repositories { addFirst(maven(mavenRemote)) } }
-                  repositories { addFirst(maven(mavenRemote)) }
+                  buildscript { repositories { def r = maven(mavenRemote); remove(r); addFirst(r) } }
+                  repositories { def r = maven(mavenRemote); remove(r); addFirst(r) }
               }
```

## Verification

Empirically confirmed on the `plugin-gcp` **v2.7.0** tag build: run `28153864024` (after #141 merged) still failed in 10s with `Cannot add a repository with name 'GcpMavenRemote' as a repository with that name already exists`.

## Context / chain

#136 introduced the init script → #138 fixed an unrelated `secrets`-in-`if:` parse error → #140 fixed the `maven()` method scope → #141 added a unique repo name → **this PR** removes the double-add. Blocks releases across all plugin repos using `plugins.yml@main`.

## Test plan

- [ ] CI passes on a plugin repo with `GCP_SERVICE_ACCOUNT` set — both a snapshot build and a tag/release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)