### PR TITLE
fix(ci): guard GcpMavenRemote repo add with findByName to avoid duplicates

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -137,8 +137,8 @@ jobs:
           if (token) {
               def mavenRemote = { name = "GcpMavenRemote"; url "https://europe-maven.pkg.dev/kestra-host/maven-remote"; credentials { username "oauth2accesstoken"; password token } }
               allprojects {
-                  buildscript { repositories { def r = maven(mavenRemote); remove(r); addFirst(r) } }
-                  repositories { def r = maven(mavenRemote); remove(r); addFirst(r) }
+                  buildscript { repositories { if (!repositories.findByName("GcpMavenRemote")) addFirst(maven(mavenRemote)) } }
+                  repositories { if (!findByName("GcpMavenRemote")) addFirst(maven(mavenRemote)) }
               }
           }
           EOF


### PR DESCRIPTION
## Summary

- `allprojects` iterates per project; buildscript repos are shared across the hierarchy, so `addFirst(maven(...))` was called multiple times on the same container
- Fix: guard with `findByName("GcpMavenRemote")` before adding in both `buildscript` and regular `repositories` blocks

Follows #141.

## Test plan

- [ ] CI passes on `plugin-debezium` and `plugin-serdes`