### PR TITLE
fix(ci): fix GcpMavenRemote duplicate-add in Gradle 9 init script

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -135,10 +135,20 @@ jobs:
           cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
           def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
           if (token) {
-              def mavenRemote = { name = "GcpMavenRemote"; url "https://europe-maven.pkg.dev/kestra-host/maven-remote"; credentials { username "oauth2accesstoken"; password token } }
+              def injectProxy = { repos ->
+                  if (!repos.findByName("GcpMavenRemote")) {
+                      def r = repos.maven {
+                          name = "GcpMavenRemote"
+                          url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
+                          credentials { username = "oauth2accesstoken"; password = token }
+                      }
+                      repos.remove(r)
+                      repos.addFirst(r)
+                  }
+              }
               allprojects {
-                  buildscript { repositories { if (!repositories.findByName("GcpMavenRemote")) addFirst(maven(mavenRemote)) } }
-                  repositories { if (!findByName("GcpMavenRemote")) addFirst(maven(mavenRemote)) }
+                  injectProxy(buildscript.repositories)
+                  injectProxy(repositories)
               }
           }
           EOF


### PR DESCRIPTION
## Summary

- `maven(closure)` in Gradle 9 auto-adds the repo to the `RepositoryHandler`, so `addFirst(maven(...))` always throws \"Cannot add a repository with name 'GcpMavenRemote' as a repository with that name already exists\" — the `findByName` guard only prevented a *second* `allprojects` call, not the within-call double-add
- `repositories.findByName()` inside `buildscript { repositories { } }` resolved `repositories` up the Groovy delegate chain to `Project.repositories` instead of `buildscript.repositories`, making that guard ineffective anyway

**Fix:** pass `RepositoryHandler` explicitly to an `injectProxy` closure, call `maven { }` (auto-adds at end), then `remove` + `addFirst` to move it to front. No scope ambiguity, no double-add.

## Test plan

- [ ] Re-run failing job on plugin-serdes: https://github.com/kestra-io/plugin-serdes/actions/runs/28154263512/job/83378921041