### PR TITLE
fix(ci): add GCP maven-remote proxy as fallback, not first repo

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -137,13 +137,11 @@ jobs:
           if (token) {
               def injectProxy = { repos ->
                   if (!repos.findByName("GcpMavenRemote")) {
-                      def r = repos.maven {
+                      repos.maven {
                           name = "GcpMavenRemote"
                           url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
                           credentials { username = "oauth2accesstoken"; password = token }
                       }
-                      repos.remove(r)
-                      repos.addFirst(r)
                   }
               }
               allprojects {


### PR DESCRIPTION
## Root cause

`repos.addFirst` put the GCP AR proxy as the first repository for every Gradle resolution. Gradle's dependency cache is keyed by repository URL — the restored `~/.gradle/caches` had entries keyed to `repo1.maven.org`, not `europe-maven.pkg.dev`. No cache hits → Gradle re-downloaded everything through a Europe-region endpoint on every run.

## Measured regression

Step timings from plugin-airflow CI runs:

| Step | Before PR #136 | After PR #136 | Delta |
|------|---------------|---------------|-------|
| GCP - Auth | skipped | 0s | — |
| Setup - Gradle maven-remote init script | — | 0s | — |
| **Test - Gradle Check** | **31s** | **4m57s** | **+4m26s** |
| Total job | 4m10s | 9m28s | +5m18s |

- Before: https://github.com/kestra-io/plugin-airflow/actions/runs/26639038297/job/78506748080
- After: https://github.com/kestra-io/plugin-airflow/actions/runs/28159828935/job/83397264264

## Fix

Drop `repos.remove(r)` + `repos.addFirst(r)` — the proxy is now appended as a fallback repo. Gradle tries Maven Central first (fast when cache is warm), and only falls back to the proxy if Maven Central returns a 4xx (cold cache + GitHub Actions runner IP 403).

## QA — 403 fallback behaviour on Gradle 9.5

Tested locally against plugin-airflow (Gradle 9.5.0).

**Setup:** spun up a local HTTP server returning 403 on every request, injected it as the *first* Maven repository via a Gradle init script, then ran:

```
./gradlew dependencies --configuration runtimeClasspath --refresh-dependencies
```

**Result:** resolution succeeded — Gradle fell through to Maven Central on every 403 hit.

**Conclusion:** Gradle 9.5 treats 403 the same as 404 (not found in this repo → try next). The proxy-as-fallback approach is safe:

- **Warm cache** → Maven Central first, local cache hit, proxy never reached → back to ~31s
- **Cold cache + Maven Central 403** → Gradle falls back to GCP AR proxy → resolves correctly

## Test plan

- [ ] Next `plugin-airflow` CI run should show `Test - Gradle Check` back near 31s on warm cache
- [ ] Cold-cache run (after 7-day cache expiry) still resolves via proxy fallback