### PR TITLE
fix(ci): restore GCP maven-remote proxy as first repo

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -137,11 +137,13 @@ jobs:
           if (token) {
               def injectProxy = { repos ->
                   if (!repos.findByName("GcpMavenRemote")) {
-                      repos.maven {
+                      def r = repos.maven {
                           name = "GcpMavenRemote"
                           url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
                           credentials { username = "oauth2accesstoken"; password = token }
                       }
+                      repos.remove(r)
+                      repos.addFirst(r)
                   }
               }
               allprojects {


### PR DESCRIPTION
## Context

PR #145 made the GCP AR proxy a fallback repo to fix a 5-minute regression seen on plugin-airflow:

| Run | `Test - Gradle Check` |
|-----|----------------------|
| Before proxy (#136) | 31s |
| First proxy-first run | 4m57s |
| After #145 (proxy fallback) | 36s |

## Why #145 was wrong

The 4m57s was a **one-time cold-proxy warm-up cost**, not a persistent regression. Gradle's dependency cache is URL-keyed — the first proxy-first run found no cache entries under `europe-maven.pkg.dev` and re-downloaded everything. The second proxy-first run would have been ~36s with a warm proxy-keyed `~/.gradle/caches`.

Making the proxy a fallback means it is **never called on warm-cache runs** (Maven Central succeeds, proxy is skipped entirely). This defeats the intent: route all Maven traffic through the GCP AR caching proxy, not just rescue 403s.

## Fix

Revert to `addFirst` — proxy is first for every resolution. Trade-off: ~5 min one-time warm-up after a GH Actions cache miss (7-day expiry). After that run, proxy-keyed cache entries are saved and restored, keeping subsequent runs fast.

## Test plan

- [ ] First run after merge will be slow (~5 min `Test - Gradle Check`) — expected one-time cost
- [ ] Second run should be back to ~36s
- [ ] Maven-remote repo visible in Gradle resolution logs