### PR TITLE
fix(ci): inject GcpMavenRemote into pluginManagement for plugins{} block resolution

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -144,6 +144,9 @@ jobs:
                       }
                   }
               }
+              beforeSettings { settings ->
+                  injectProxy(settings.pluginManagement.repositories)
+              }
               allprojects {
                   injectProxy(buildscript.repositories)
                   injectProxy(repositories)


### PR DESCRIPTION
## Summary

- The `maven-remote.gradle` init script only injected `GcpMavenRemote` into `allprojects { buildscript.repositories }`, which does **not** cover `plugins {}` DSL block resolution
- Gradle resolves `plugins {}` declarations through `pluginManagement.repositories` (from `settings.gradle`) + the Gradle Plugin Portal only — not from `buildscript.repositories`
- Previous builds worked because the `inject-bom-versions` plugin JAR was in the Gradle dependencies cache; after bumping to `1.2.2` in plugin repos, the cache misses and the build fails at settings evaluation with _"Plugin [...inject-bom-versions:1.2.2] was not found"_

Fix: add a `beforeSettings` hook to also inject `GcpMavenRemote` into `settings.pluginManagement.repositories`, which is the correct hook for covering `plugins {}` block resolution from an init script.

## Affected repos

`plugin-ee-gcp` main is currently red ([run 28167556017](https://github.com/kestra-io/plugin-ee-gcp/actions/runs/28167556017)). Any other plugin repo that bumps `inject-bom-versions` (or any other private Gradle plugin) will hit the same failure on cache miss.

## Test plan

- [ ] Re-trigger `plugin-ee-gcp` main after merge — build should reach compilation
- [ ] Verify `plugin-ai` scheduled run passes on next trigger