### PR TITLE
fix(release): let announce-slack input control Slack announcements

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -99,8 +99,7 @@ files:
     - pattern: "!certs/**"
 
 announce:
-  slack:
-    active: 'ALWAYS' # TODO: maybe switch to RELEASE only?
+  slack: {} # `active` is driven by JRELEASER_ANNOUNCE_SLACK_ACTIVE (github-release action's announce-slack input). Do not hardcode `active` here: an explicit config value takes precedence over the env var and would force announcements ON regardless of the input.
 
 upload:
   active: ALWAYS


### PR DESCRIPTION
## Problem

Passing `announce-slack: 'false'` to the `github-release` composite action still sends a Slack announcement.

## Root cause

The action correctly exports `JRELEASER_ANNOUNCE_SLACK_ACTIVE=NEVER` (the ternary at `composite/github-release/action.yml:77` is valid). However, `jreleaser.yml` hardcoded:

```yaml
announce:
  slack:
    active: 'ALWAYS'
```

JReleaser's precedence is **explicit config value > system property > environment variable** — the env var only applies when the property is *not* set in the file. So the hardcoded `ALWAYS` silently overrode the env var and Slack always fired.

## Fix

Drop the hardcoded `active` so `JRELEASER_ANNOUNCE_SLACK_ACTIVE` (driven by the `announce-slack` input) becomes authoritative:
- `announce-slack: 'true'` (default) → `ALWAYS` → unchanged for existing consumers
- `announce-slack: 'false'` → `NEVER` → no announcement

Refs: [JReleaser environment precedence](https://jreleaser.org/guide/latest/reference/environment.html)