### PR TITLE
ci(kestra-ee): wait for services to be healthy before tests

### DIFF
--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -74,7 +74,12 @@ jobs:
 
       # Services
       - name: Setup - Start docker compose
-        run: docker compose -f docker-compose-ci.yml up -d
+        # --wait blocks until every service with a healthcheck reports healthy (and the rest
+        # are running), so the Gradle check below no longer races container startup. This
+        # removes environmental failures like 'Connection refused' / MySQL 'Communications
+        # link failure' from tests that connect before the shared services are ready.
+        # Requires the healthchecks added in kestra-ee's docker-compose-ci.yml.
+        run: docker compose -f docker-compose-ci.yml up -d --wait --wait-timeout 120
 
       # Gradle check
       - name: Gradle - check and javadoc


### PR DESCRIPTION
## What

Part of the kestra-ee Backend-job resource-contention effort (Tier 1). Changes the service startup in `kestra-ee-backend-tests.yml` from:

```
docker compose -f docker-compose-ci.yml up -d
```
to:
```
docker compose -f docker-compose-ci.yml up -d --wait --wait-timeout 120
```

## Why

Today the job starts the backing services and **immediately** runs `./gradlew check`, so tests can connect **before the services are ready**. On no-op ("dummy") PRs this alone produces environmental failures — `Connection refused` (gRPC/DB) and MySQL `Communications link failure` — that have nothing to do with the code under test.

With `--wait`, Compose blocks until every service that has a healthcheck reports **healthy** (and the rest are running) before the build starts.

## Depends on

Companion PR in kestra-io/kestra-ee (**#9177**) adds the healthchecks to `docker-compose-ci.yml` (postgres/mysql/redis/rabbitmq; elasticsearch already had one). Because the EE workflow pins this reusable workflow at `@main`, this only takes effect once merged — and is fully effective once #9177 is also merged. Ordering is safe: `--wait` still waits for "running" state even before the healthchecks land.

## Notes

- `--wait-timeout 120` bounds the wait so a genuinely stuck service fails fast with a clear cause instead of the build hanging.
- Kafka currently has no healthcheck (see #9177), so `--wait` treats it as ready when running — unchanged from today.
- Scoped to the EE workflow; the OSS workflow can get the same treatment as a follow-up.