### PR TITLE
ci(plugins): run UI unit tests in the shared workflow

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -88,6 +88,9 @@ jobs:
           # Use Java 25 only for Kestra 2.x (including SNAPSHOT)
           java-version: ${{ startsWith(inputs.kestra-version, '2.') && env.COMPATIBILITY_JAVA_VERSION || inputs.java-version }}
           java-enable-develocity-injection: true
+          # Set up Node only for plugins that ship a UI micro-frontend (ui/package-lock.json),
+          # so setup-node's npm cache doesn't fail on the majority of plugins without one.
+          node-enabled: ${{ hashFiles('ui/package-lock.json') != '' }}
   
       # Setup OpenTelemetry: root span context, background host-metrics collector, and a
       # Gradle init script that emits a span per task and per JUnit test (nested under the
@@ -193,6 +196,19 @@ jobs:
           if [ -f .github/cleanup-unit.sh ]; then
             ./.github/cleanup-unit.sh
           fi
+
+      # UI unit tests (Vitest, jsdom — no browser download) for plugins that ship a Vue
+      # micro-frontend under ui/. Guarded on ui/package-lock.json so it is a no-op for the
+      # plugins that have no UI; Node itself is set up conditionally in "Setup - Build".
+      # --if-present keeps repos that lack a lint/test:unit script from failing.
+      - name: Test - UI unit tests
+        if: ${{ inputs.skip-test == false && hashFiles('ui/package-lock.json') != '' }}
+        working-directory: ui
+        shell: bash
+        run: |
+          npm ci
+          npm run --if-present lint
+          npm run --if-present test:unit
 
       # Avoid duplicate publishing on release commits:
       # when a main/master push points to a release tag, only the tag workflow should publish.


### PR DESCRIPTION
## Summary

Fold the per-repo `ui-tests.yml` — currently being **ported across plugin repos** (e.g. [plugin-ee-aws#170](https://github.com/kestra-io/plugin-ee-aws/pull/170), [plugin-ee-gcp#156](https://github.com/kestra-io/plugin-ee-gcp/pull/156)) — into the shared reusable `plugins.yml`, so every plugin's thin `main.yml` picks it up **once** with no duplicated workflow to maintain.

Addresses the review comment on plugin-ee-gcp#156: *"Cannot we make `plugins.yml` in `actions` repo run this once through each `main.yml` workflow from local plugin repos?"*

## Changes

- **Conditional Node setup** on the existing `Setup - Build` step: `node-enabled: ${{ hashFiles('ui/package-lock.json') != '' }}`. Gated because `setup-node`'s npm cache **errors** when no `package-lock.json` exists — enabling it unconditionally would break every plugin without a `ui/`.
- **New `Test - UI unit tests` step** (after the Gradle test cleanup, before publish), guarded on `skip-test == false && hashFiles('ui/package-lock.json') != ''`, running `npm ci` + `npm run --if-present lint` + `npm run --if-present test:unit` in `ui/`. `--if-present` tolerates repos with a `ui/` but no `lint`/`test:unit` script.

## Behavior / trade-offs

- Near-zero no-op for the plugins that have **no** `ui/` micro-frontend.
- Runs as a **step in the existing `main` job** (sequential with the Gradle build), not a separate/parallel job — fine for a fast jsdom test with no browser download.
- Runs on **every** `main.yml` trigger, not path-filtered to `ui/**` like the standalone workflow. Acceptable given the guard makes it free without a UI.

## Follow-up (separate PRs)

- Delete `ui-tests.yml` from `plugin-ee-gcp` (and don't port it to other repos) once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)