### PR TITLE
fix(plugins): run unit-test cleanup even when tests fail

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -187,11 +187,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       # Cleanup unit tests environment.
-      # Uses !cancelled() (not the implicit success()) so teardown still runs when
-      # "Test - Gradle Check" fails — that is exactly when a test may have leaked
-      # resources (e.g. objects in a shared cloud bucket) and cleanup matters most.
       - name: Cleanup - Unit test
-        if: ${{ !cancelled() && inputs.skip-test == false }}
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -186,9 +186,12 @@ jobs:
           JAVA_OPTS: "-Xmx2g -XX:MaxMetaspaceSize=1g"
           GITHUB_TOKEN: ${{ github.token }}
 
-      # Cleanup unit tests environment
+      # Cleanup unit tests environment.
+      # Uses !cancelled() (not the implicit success()) so teardown still runs when
+      # "Test - Gradle Check" fails — that is exactly when a test may have leaked
+      # resources (e.g. objects in a shared cloud bucket) and cleanup matters most.
       - name: Cleanup - Unit test
-        if: ${{ inputs.skip-test == false }}
+        if: ${{ !cancelled() && inputs.skip-test == false }}
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

The reusable plugin workflow's **Cleanup - Unit test** step runs `.github/cleanup-unit.sh`, which plugins use to reclaim resources created during integration tests (for example, leftover objects in a shared cloud bucket).

Its condition was:

```yaml
if: ${{ inputs.skip-test == false }}
```

Because that expression contains no status-check function, GitHub Actions wraps it in an implicit `success()`. As a result the cleanup step is **skipped whenever `Test - Gradle Check` fails** — which is exactly the case where a test is most likely to have leaked resources and left them behind.

Concrete impact: the `plugin-huawei` OBS integration tests run against a shared, persistent Huawei OBS bucket in CI. When a test fails mid-run, its objects are never cleaned up and accumulate in the bucket until the 1-day lifecycle rule eventually reaps them.

## Fix

Switch the condition to:

```yaml
if: ${{ !cancelled() && inputs.skip-test == false }}
```

This makes teardown run on test **failure** (when it matters most) while still being skipped on **cancellation**. It matches the idiom already used elsewhere in this same workflow (the Trivy/report steps at the bottom use `!cancelled() && inputs.skip-test == false`).

## Scope / blast radius

This is a shared workflow used by all `kestra-io/plugin-*` repos. The change only affects the *conditions under which* an already-existing, opt-in step runs — repos without a `.github/cleanup-unit.sh` are unaffected (the step is a no-op for them). No behavior change on success or when tests are skipped.

## Note

This addresses the "cleanup skipped on failure" gap only. It does not make a blanket-wipe cleanup script concurrency-safe on a shared bucket — that still requires per-run key scoping on the plugin side. See plugin-huawei for the companion change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)