### PR TITLE
fix(plugins): actually run unit-test cleanup on test failure

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -187,7 +187,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       # Cleanup unit tests environment.
+      # !cancelled() (not the implicit success()) is required so teardown still runs when
+      # "Test - Gradle Check" fails — that is exactly when a test may have leaked resources
+      # (e.g. objects in a shared cloud bucket) and cleanup matters most. Without an explicit
+      # status function a step defaults to success() and is skipped on any prior failure.
       - name: Cleanup - Unit test
+        if: ${{ !cancelled() && inputs.skip-test == false }}
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Follow-up to #152

#152 was intended to make the **Cleanup - Unit test** step run even when tests fail, but it was simplified before merge to just *delete* the `if:` line:

```diff
       - name: Cleanup - Unit test
-        if: ${{ inputs.skip-test == false }}
         env:
```

A step with **no `if:`** defaults to `success()` in GitHub Actions, so it is still **skipped whenever `Test - Gradle Check` fails** — which is exactly when a test is most likely to have leaked resources. So the original bug is still present on `main`.

## Fix

Add an explicit status function:

```yaml
if: ${{ !cancelled() && inputs.skip-test == false }}
```

`!cancelled()` forces the step to run despite a prior failure, while still skipping on cancellation. This matches the idiom already used by the Trivy/report steps lower in this same workflow.

## Impact

Shared workflow used by all `kestra-io/plugin-*` repos. Only changes *when* an already-existing, opt-in step runs — repos without `.github/cleanup-unit.sh` are unaffected (no-op). No change on the success path.

Concrete driver: `plugin-huawei` OBS integration tests run against a shared, persistent Huawei OBS bucket; on a failing run the leaked objects are currently never cleaned up. Paired with kestra-io/plugin-huawei#51 (run-scoped `cleanup-unit.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)