### PR TITLE
fix(ci): route EE core build Maven reads through GCP AR proxy (429 mitigation)

### DIFF
--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -57,6 +57,56 @@ jobs:
           java-enabled: true
           java-version: ${{ inputs.java-version }}
 
+      # Route Gradle Maven reads through the GCP Artifact Registry maven-remote caching proxy
+      # to avoid Maven Central HTTP 429 rate-limiting on shared GitHub Actions runner IPs.
+      # The token is passed at build time via MAVEN_REMOTE_TOKEN; the script is a no-op when empty.
+      - name: GCP - Check credentials availability
+        id: gcp-check
+        run: echo "available=${{ secrets.GOOGLE_SERVICE_ACCOUNT != '' }}" >> $GITHUB_OUTPUT
+
+      - name: GCP - Auth for maven-remote proxy
+        id: gcp-auth
+        uses: 'google-github-actions/auth@v3'
+        if: steps.gcp-check.outputs.available == 'true'
+        with:
+          token_format: 'access_token'
+          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+
+      - name: Setup - Gradle maven-remote init script
+        if: ${{ steps.gcp-auth.outputs.access_token != '' }}
+        shell: bash
+        run: |
+          mkdir -p ~/.gradle/init.d
+          cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
+          def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
+          def injectProxy = { repos ->
+              if (token && !repos.findByName("GcpMavenRemote")) {
+                  repos.maven {
+                      name = "GcpMavenRemote"
+                      url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
+                      credentials { username = "oauth2accesstoken"; password = token }
+                  }
+              }
+          }
+          // Always restore explicit repos: touching pluginManagement.repositories via beforeSettings
+          // drops the implicit gradlePluginPortal() default, so we re-add it unconditionally.
+          beforeSettings { settings ->
+              injectProxy(settings.pluginManagement.repositories)
+              if (!settings.pluginManagement.repositories.findByName("Gradle Plugin Portal")) {
+                  settings.pluginManagement.repositories.gradlePluginPortal()
+              }
+              if (!settings.pluginManagement.repositories.findByName("MavenRepo")) {
+                  settings.pluginManagement.repositories.mavenCentral()
+              }
+          }
+          if (token) {
+              allprojects {
+                  injectProxy(buildscript.repositories)
+                  injectProxy(repositories)
+              }
+          }
+          EOF
+
       - name: OpenTelemetry - Setup
         uses: kestra-io/actions/actions/otel-collect@main
         if: ${{ env.OTLP_ENDPOINT != '' }}
@@ -83,6 +133,8 @@ jobs:
 
       # Gradle check
       - name: Gradle - check and javadoc
+        env:
+          MAVEN_REMOTE_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
         run: |
           echo $GOOGLE_SERVICE_ACCOUNT | base64 -d > $(pwd)/.gcp-service-account.json
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.gcp-service-account.json

--- a/.github/workflows/kestra-ee-build-artifacts.yml
+++ b/.github/workflows/kestra-ee-build-artifacts.yml
@@ -33,6 +33,7 @@ jobs:
         if: ${{ env.GOOGLE_SERVICE_ACCOUNT != 0 }}
         uses: 'google-github-actions/auth@v3'
         with:
+          token_format: 'access_token'
           credentials_json: '${{ env.GOOGLE_SERVICE_ACCOUNT }}'
 
       # Checkout
@@ -50,6 +51,44 @@ jobs:
           java-enabled: 'true'
           node-enabled: 'true'
           java-version: ${{ inputs.java-version }}
+
+      # Route Gradle Maven reads through the GCP Artifact Registry maven-remote caching proxy
+      # to avoid Maven Central HTTP 429 rate-limiting on shared GitHub Actions runner IPs.
+      # The token is passed at build time via MAVEN_REMOTE_TOKEN; the script is a no-op when empty.
+      - name: Setup - Gradle maven-remote init script
+        if: ${{ steps.auth.outputs.access_token != '' }}
+        shell: bash
+        run: |
+          mkdir -p ~/.gradle/init.d
+          cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
+          def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
+          def injectProxy = { repos ->
+              if (token && !repos.findByName("GcpMavenRemote")) {
+                  repos.maven {
+                      name = "GcpMavenRemote"
+                      url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
+                      credentials { username = "oauth2accesstoken"; password = token }
+                  }
+              }
+          }
+          // Always restore explicit repos: touching pluginManagement.repositories via beforeSettings
+          // drops the implicit gradlePluginPortal() default, so we re-add it unconditionally.
+          beforeSettings { settings ->
+              injectProxy(settings.pluginManagement.repositories)
+              if (!settings.pluginManagement.repositories.findByName("Gradle Plugin Portal")) {
+                  settings.pluginManagement.repositories.gradlePluginPortal()
+              }
+              if (!settings.pluginManagement.repositories.findByName("MavenRepo")) {
+                  settings.pluginManagement.repositories.mavenCentral()
+              }
+          }
+          if (token) {
+              allprojects {
+                  injectProxy(buildscript.repositories)
+                  injectProxy(repositories)
+              }
+          }
+          EOF
 
       - name: OpenTelemetry - Setup
         uses: kestra-io/actions/actions/otel-collect@main
@@ -86,6 +125,7 @@ jobs:
       # Shadow Jar
       - name: Gradle - Build jars
         env:
+          MAVEN_REMOTE_TOKEN: ${{ steps.auth.outputs.access_token }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |


### PR DESCRIPTION
## Why

EE CI release builds are failing to resolve Gradle **plugins and dependencies** with `429 Too Many Requests` from `repo.maven.apache.org`. Maven Central rate-limits the shared GitHub Actions runner IPs, and the Gradle Plugin Portal redirects plugin artifacts to Central — so the EE `backend-tests` and `build-artifacts` jobs fail at the **buildscript-classpath** stage (`com.gradleup.shadow`, `com.github.node-gradle.node`, `org.owasp.dependencycheck`, `io.kestra.gradle.spotless-conventions`, …). This is version-independent and hits every EE branch.

A `settings.gradle` Central-mirror workaround was insufficient: third-party plugin **markers** are Plugin-Portal-only (absent from Central mirrors), and the 429 actually occurs on `buildscript.repositories`, not `pluginManagement`.

## What

Replicate the **already-proven** `maven-remote` init-script pattern from `plugins.yml` into the two EE core reusable workflows:

- `kestra-ee-backend-tests.yml`
- `kestra-ee-build-artifacts.yml`

Each mints a GCP access token from the `GOOGLE_SERVICE_ACCOUNT` **already available to these jobs** (`google-github-actions/auth@v3` + `token_format: access_token`) and writes `~/.gradle/init.d/maven-remote.gradle`, which routes Maven reads through the `GcpMavenRemote` proxy (`europe-maven.pkg.dev/kestra-host/maven-remote`) — an authenticated Artifact Registry remote that fronts **both** Maven Central and the Gradle Plugin Portal, so it isn't throttled. `gradlePluginPortal()`/`mavenCentral()` remain as fallbacks. The script is a **no-op when no token is present**, so behaviour is unchanged without credentials.

## Scope / blast radius

- **Only** these two EE workflows. `composite/setup-build`, all OSS pipelines, `plugins.yml`, e2e and publish workflows are untouched → **no plugin-pipeline impact**.
- Because they're referenced `@main`, this reaches every EE branch (develop + all release branches) with **no per-branch commit**.

## Prerequisite ⚠️

The `GOOGLE_SERVICE_ACCOUNT` service account must have `roles/artifactregistry.reader` on `kestra-host/maven-remote` (region `europe`). `plugins.yml` proves `GCP_SERVICE_ACCOUNT` has it; the unit-test SA is **unverified** — please confirm or grant before merging. Without read access the proxy auth would 401.

## Rollback

Revert this change; the init script is `if`-guarded on a non-empty token, so absent/invalid credentials leave resolution behaviour unchanged.

Refs kestra-ee#9409 (comprehensive rollout: OSS builds, `global-create-new-release-branch`, removing the interim mirror blocks).
