### PR TITLE
fix(otel-collect): route init-script classpath through GCP maven mirror

### DIFF
--- a/actions/otel-collect/dist/index.js
+++ b/actions/otel-collect/dist/index.js
@@ -87679,7 +87679,20 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 initscript {
-  repositories { mavenCentral() }
+  repositories {
+    // Use the GCP pull-through mirror when MAVEN_REMOTE_TOKEN is set so cold-cache
+    // builds don't hit Maven Central directly and get 429'd. Falls back to mavenCentral().
+    def mavenRemoteToken = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
+    if (!mavenRemoteToken.isEmpty()) {
+      maven {
+        name = "GcpMavenRemote"
+        url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
+        credentials { username = "oauth2accesstoken"; password = mavenRemoteToken }
+        authentication { basic(BasicAuthentication) }
+      }
+    }
+    mavenCentral()
+  }
   dependencies {
     classpath "io.opentelemetry:opentelemetry-sdk:1.43.0"
     classpath "io.opentelemetry:opentelemetry-exporter-otlp:1.43.0"

--- a/actions/otel-collect/src/gradle.ts
+++ b/actions/otel-collect/src/gradle.ts
@@ -30,7 +30,20 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 initscript {
-  repositories { mavenCentral() }
+  repositories {
+    // Use the GCP pull-through mirror when MAVEN_REMOTE_TOKEN is set so cold-cache
+    // builds don't hit Maven Central directly and get 429'd. Falls back to mavenCentral().
+    def mavenRemoteToken = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
+    if (!mavenRemoteToken.isEmpty()) {
+      maven {
+        name = "GcpMavenRemote"
+        url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
+        credentials { username = "oauth2accesstoken"; password = mavenRemoteToken }
+        authentication { basic(BasicAuthentication) }
+      }
+    }
+    mavenCentral()
+  }
   dependencies {
     classpath "io.opentelemetry:opentelemetry-sdk:1.43.0"
     classpath "io.opentelemetry:opentelemetry-exporter-otlp:1.43.0"


### PR DESCRIPTION
The OTel init script resolved its `initscript` classpath from `mavenCentral()` directly, so cold-cache builds 429 on Maven Central. The `maven-remote.gradle` mirror can't reach an init script's own classpath (resolved before settings/project).

Inject `GcpMavenRemote` (via `MAVEN_REMOTE_TOKEN`, already set on the build step) into the `initscript` repositories, with `mavenCentral()` as fallback. Same pattern as `plugins.yml`. `dist/` rebuilt.