### PR TITLE
revert: EE core maven-remote proxy (#154) — breaks builds on unit-test SA

### DIFF
--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -57,56 +57,6 @@ jobs:
           java-enabled: true
           java-version: ${{ inputs.java-version }}
 
-      # Route Gradle Maven reads through the GCP Artifact Registry maven-remote caching proxy
-      # to avoid Maven Central HTTP 429 rate-limiting on shared GitHub Actions runner IPs.
-      # The token is passed at build time via MAVEN_REMOTE_TOKEN; the script is a no-op when empty.
-      - name: GCP - Check credentials availability
-        id: gcp-check
-        run: echo "available=${{ secrets.GOOGLE_SERVICE_ACCOUNT != '' }}" >> $GITHUB_OUTPUT
-
-      - name: GCP - Auth for maven-remote proxy
-        id: gcp-auth
-        uses: 'google-github-actions/auth@v3'
-        if: steps.gcp-check.outputs.available == 'true'
-        with:
-          token_format: 'access_token'
-          credentials_json: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-
-      - name: Setup - Gradle maven-remote init script
-        if: ${{ steps.gcp-auth.outputs.access_token != '' }}
-        shell: bash
-        run: |
-          mkdir -p ~/.gradle/init.d
-          cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
-          def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
-          def injectProxy = { repos ->
-              if (token && !repos.findByName("GcpMavenRemote")) {
-                  repos.maven {
-                      name = "GcpMavenRemote"
-                      url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
-                      credentials { username = "oauth2accesstoken"; password = token }
-                  }
-              }
-          }
-          // Always restore explicit repos: touching pluginManagement.repositories via beforeSettings
-          // drops the implicit gradlePluginPortal() default, so we re-add it unconditionally.
-          beforeSettings { settings ->
-              injectProxy(settings.pluginManagement.repositories)
-              if (!settings.pluginManagement.repositories.findByName("Gradle Plugin Portal")) {
-                  settings.pluginManagement.repositories.gradlePluginPortal()
-              }
-              if (!settings.pluginManagement.repositories.findByName("MavenRepo")) {
-                  settings.pluginManagement.repositories.mavenCentral()
-              }
-          }
-          if (token) {
-              allprojects {
-                  injectProxy(buildscript.repositories)
-                  injectProxy(repositories)
-              }
-          }
-          EOF
-
       - name: OpenTelemetry - Setup
         uses: kestra-io/actions/actions/otel-collect@main
         if: ${{ env.OTLP_ENDPOINT != '' }}
@@ -133,8 +83,6 @@ jobs:
 
       # Gradle check
       - name: Gradle - check and javadoc
-        env:
-          MAVEN_REMOTE_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
         run: |
           echo $GOOGLE_SERVICE_ACCOUNT | base64 -d > $(pwd)/.gcp-service-account.json
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.gcp-service-account.json

--- a/.github/workflows/kestra-ee-build-artifacts.yml
+++ b/.github/workflows/kestra-ee-build-artifacts.yml
@@ -33,7 +33,6 @@ jobs:
         if: ${{ env.GOOGLE_SERVICE_ACCOUNT != 0 }}
         uses: 'google-github-actions/auth@v3'
         with:
-          token_format: 'access_token'
           credentials_json: '${{ env.GOOGLE_SERVICE_ACCOUNT }}'
 
       # Checkout
@@ -51,44 +50,6 @@ jobs:
           java-enabled: 'true'
           node-enabled: 'true'
           java-version: ${{ inputs.java-version }}
-
-      # Route Gradle Maven reads through the GCP Artifact Registry maven-remote caching proxy
-      # to avoid Maven Central HTTP 429 rate-limiting on shared GitHub Actions runner IPs.
-      # The token is passed at build time via MAVEN_REMOTE_TOKEN; the script is a no-op when empty.
-      - name: Setup - Gradle maven-remote init script
-        if: ${{ steps.auth.outputs.access_token != '' }}
-        shell: bash
-        run: |
-          mkdir -p ~/.gradle/init.d
-          cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
-          def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
-          def injectProxy = { repos ->
-              if (token && !repos.findByName("GcpMavenRemote")) {
-                  repos.maven {
-                      name = "GcpMavenRemote"
-                      url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
-                      credentials { username = "oauth2accesstoken"; password = token }
-                  }
-              }
-          }
-          // Always restore explicit repos: touching pluginManagement.repositories via beforeSettings
-          // drops the implicit gradlePluginPortal() default, so we re-add it unconditionally.
-          beforeSettings { settings ->
-              injectProxy(settings.pluginManagement.repositories)
-              if (!settings.pluginManagement.repositories.findByName("Gradle Plugin Portal")) {
-                  settings.pluginManagement.repositories.gradlePluginPortal()
-              }
-              if (!settings.pluginManagement.repositories.findByName("MavenRepo")) {
-                  settings.pluginManagement.repositories.mavenCentral()
-              }
-          }
-          if (token) {
-              allprojects {
-                  injectProxy(buildscript.repositories)
-                  injectProxy(repositories)
-              }
-          }
-          EOF
 
       - name: OpenTelemetry - Setup
         uses: kestra-io/actions/actions/otel-collect@main
@@ -125,7 +86,6 @@ jobs:
       # Shadow Jar
       - name: Gradle - Build jars
         env:
-          MAVEN_REMOTE_TOKEN: ${{ steps.auth.outputs.access_token }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |


### PR DESCRIPTION
Reverts #154. That change added `google-github-actions/auth` steps with `token_format: access_token` using `GOOGLE_SERVICE_ACCOUNT` (the `kestra-unit-test` SA), which cannot mint access tokens (`iam.serviceAccounts.getAccessToken` denied → hard 403). This turned the intermittent Maven Central 429 into a deterministic failure on every EE `backend-tests` and `build-artifacts` run, and adding `token_format` to build-artifacts' pre-existing auth step broke that step too.

Reverting to restore the prior state. A corrected version using `GCP_SERVICE_ACCOUNT` (mirroring `plugins.yml`) + the required consumer secret-passing will follow. Refs kestra-ee#9409.