### PR TITLE
fix(ci): EE core Maven reads via GCP AR proxy using GCP_SERVICE_ACCOUNT (redo of #154)

### DIFF
--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -9,6 +9,9 @@ on:
       GOOGLE_SERVICE_ACCOUNT:
         description: "The Google Service Account."
         required: false
+      GCP_SERVICE_ACCOUNT:
+        description: "The GCP service account used to authenticate to the maven-remote Artifact Registry proxy."
+        required: false
       CODECOV_TOKEN:
         description: "The Codecov token."
         required: false
@@ -57,6 +60,56 @@ jobs:
           java-enabled: true
           java-version: ${{ inputs.java-version }}
 
+      # Route Gradle Maven reads through the GCP AR maven-remote caching proxy to avoid Maven
+      # Central HTTP 429 rate-limiting on shared runner IPs. Mirrors plugins.yml; no-op without a token.
+      - name: GCP - Check credentials availability
+        id: gcp-check
+        run: echo "available=${{ secrets.GCP_SERVICE_ACCOUNT != '' }}" >> $GITHUB_OUTPUT
+
+      - name: GCP - Auth with github service account
+        id: gcp-auth
+        uses: 'google-github-actions/auth@v3'
+        if: steps.gcp-check.outputs.available == 'true'
+        with:
+          token_format: 'access_token'
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          export_environment_variables: false
+
+      - name: Setup - Gradle maven-remote init script
+        if: ${{ steps.gcp-auth.outputs.access_token != '' }}
+        shell: bash
+        run: |
+          mkdir -p ~/.gradle/init.d
+          cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
+          def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
+          def injectProxy = { repos ->
+              if (token && !repos.findByName("GcpMavenRemote")) {
+                  repos.maven {
+                      name = "GcpMavenRemote"
+                      url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
+                      credentials { username = "oauth2accesstoken"; password = token }
+                  }
+              }
+          }
+          // Always restore explicit repos: touching pluginManagement.repositories via beforeSettings
+          // drops the implicit gradlePluginPortal() default, so we re-add it unconditionally.
+          beforeSettings { settings ->
+              injectProxy(settings.pluginManagement.repositories)
+              if (!settings.pluginManagement.repositories.findByName("Gradle Plugin Portal")) {
+                  settings.pluginManagement.repositories.gradlePluginPortal()
+              }
+              if (!settings.pluginManagement.repositories.findByName("MavenRepo")) {
+                  settings.pluginManagement.repositories.mavenCentral()
+              }
+          }
+          if (token) {
+              allprojects {
+                  injectProxy(buildscript.repositories)
+                  injectProxy(repositories)
+              }
+          }
+          EOF
+
       - name: OpenTelemetry - Setup
         uses: kestra-io/actions/actions/otel-collect@main
         if: ${{ env.OTLP_ENDPOINT != '' }}
@@ -83,6 +136,8 @@ jobs:
 
       # Gradle check
       - name: Gradle - check and javadoc
+        env:
+          MAVEN_REMOTE_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
         run: |
           echo $GOOGLE_SERVICE_ACCOUNT | base64 -d > $(pwd)/.gcp-service-account.json
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.gcp-service-account.json

--- a/.github/workflows/kestra-ee-build-artifacts.yml
+++ b/.github/workflows/kestra-ee-build-artifacts.yml
@@ -6,6 +6,9 @@ on:
       GOOGLE_SERVICE_ACCOUNT:
         description: "The Google Service Account."
         required: true
+      GCP_SERVICE_ACCOUNT:
+        description: "The GCP service account used to authenticate to the maven-remote Artifact Registry proxy."
+        required: false
       CODECOV_TOKEN:
         description: 'Codecov Token'
         required: true
@@ -51,6 +54,56 @@ jobs:
           node-enabled: 'true'
           java-version: ${{ inputs.java-version }}
 
+      # Route Gradle Maven reads through the GCP AR maven-remote caching proxy to avoid Maven
+      # Central HTTP 429 rate-limiting on shared runner IPs. Mirrors plugins.yml; no-op without a token.
+      - name: GCP - Check credentials availability
+        id: gcp-check
+        run: echo "available=${{ secrets.GCP_SERVICE_ACCOUNT != '' }}" >> $GITHUB_OUTPUT
+
+      - name: GCP - Auth with github service account
+        id: gcp-auth
+        uses: 'google-github-actions/auth@v3'
+        if: steps.gcp-check.outputs.available == 'true'
+        with:
+          token_format: 'access_token'
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          export_environment_variables: false
+
+      - name: Setup - Gradle maven-remote init script
+        if: ${{ steps.gcp-auth.outputs.access_token != '' }}
+        shell: bash
+        run: |
+          mkdir -p ~/.gradle/init.d
+          cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
+          def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
+          def injectProxy = { repos ->
+              if (token && !repos.findByName("GcpMavenRemote")) {
+                  repos.maven {
+                      name = "GcpMavenRemote"
+                      url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
+                      credentials { username = "oauth2accesstoken"; password = token }
+                  }
+              }
+          }
+          // Always restore explicit repos: touching pluginManagement.repositories via beforeSettings
+          // drops the implicit gradlePluginPortal() default, so we re-add it unconditionally.
+          beforeSettings { settings ->
+              injectProxy(settings.pluginManagement.repositories)
+              if (!settings.pluginManagement.repositories.findByName("Gradle Plugin Portal")) {
+                  settings.pluginManagement.repositories.gradlePluginPortal()
+              }
+              if (!settings.pluginManagement.repositories.findByName("MavenRepo")) {
+                  settings.pluginManagement.repositories.mavenCentral()
+              }
+          }
+          if (token) {
+              allprojects {
+                  injectProxy(buildscript.repositories)
+                  injectProxy(repositories)
+              }
+          }
+          EOF
+
       - name: OpenTelemetry - Setup
         uses: kestra-io/actions/actions/otel-collect@main
         if: ${{ env.OTLP_ENDPOINT != '' }}
@@ -86,6 +139,7 @@ jobs:
       # Shadow Jar
       - name: Gradle - Build jars
         env:
+          MAVEN_REMOTE_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |


### PR DESCRIPTION
## Why
Re-do of #154 (reverted in #156). EE `backend-tests` and `build-artifacts` resolve Gradle plugins and dependencies from `repo.maven.apache.org`, which rate-limits (HTTP 429) the shared runner IPs and breaks release builds at the buildscript-classpath stage.

## What changed vs #154
#154 used `GOOGLE_SERVICE_ACCOUNT` (the `kestra-unit-test` SA), which **cannot mint access tokens** (`iam.serviceAccounts.getAccessToken` denied → hard 403) and broke every EE build. This version uses **`GCP_SERVICE_ACCOUNT`** — the same SA `plugins.yml` uses for the proxy, which can mint tokens and read `maven-remote`.

- `kestra-ee-backend-tests.yml` / `kestra-ee-build-artifacts.yml`: add `gcp-check` → `gcp-auth` (`GCP_SERVICE_ACCOUNT`, `token_format: access_token`) → `maven-remote` init script (verbatim from `plugins.yml`), and `MAVEN_REMOTE_TOKEN` on the Gradle step. `GCP_SERVICE_ACCOUNT` declared as an optional `workflow_call` secret.
- The new `gcp-auth` sets `export_environment_variables: false` so it only mints the proxy token and does **not** clobber the existing `GOOGLE_APPLICATION_CREDENTIALS` (unit-test account) that build-artifacts' pre-existing auth step sets. That step is otherwise untouched.
- No-op when `GCP_SERVICE_ACCOUNT` is empty.

## Required companion change
The caller must pass the secret (cross-repo reusable workflows only see secrets that are passed):
- kestra-ee `main-build.yml` → add `GCP_SERVICE_ACCOUNT` to the `backend-tests` `secrets:` block.
- kestra-ee `pre-release.yml` → add it to `backend-tests` and `build-artifacts`.
Landing on `develop` + `releases/v1.0.x` + `releases/v1.3.x`.

## Scope
Only these two EE workflows — `setup-build`, OSS pipelines and `plugins.yml` untouched. Refs kestra-ee#9409 (clean generalisation later).
