### PR TITLE
feat: includes the Cloud plugin in Docker Cloud image

### DIFF
--- a/.github/workflows/kestra-ee-build-artifacts.yml
+++ b/.github/workflows/kestra-ee-build-artifacts.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           cd kestra-ee
           if [ "${{ steps.cloud-ee.outputs.exists }}" == "true" ]; then
-            ./gradlew executableJar :cloud-ee:jar --parallel
+            ./gradlew executableJar :cloud-ee:shadowJar --parallel
           else
             ./gradlew executableJar --parallel
           fi
@@ -107,9 +107,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cloud-libs
-          path: |
-            kestra-ee/cloud-ee/build/libs/cloud-ee-*.jar
-            !kestra-ee/cloud-ee/build/libs/*-all.jar
+          path: kestra-ee/cloud-ee/build/libs/cloud-ee-*-all.jar
 
       - name: Artifacts - Transform swagger for website
         run: |

--- a/.github/workflows/kestra-ee-publish-docker.yml
+++ b/.github/workflows/kestra-ee-publish-docker.yml
@@ -275,25 +275,16 @@ jobs:
             APT_PACKAGES=${{ matrix.image.packages }}
             PYTHON_LIBRARIES=${{ matrix.image.python-libraries }}
 
-      - name: Cloud - Download cloud-ee libs
-        if: ${{ matrix.image.tag == '' && inputs.dry-run == false && github.event.client_payload.ref == '' && steps.cloud-ee.outputs.exists == 'true' }}
-        uses: actions/download-artifact@v5
-        with:
-          name: cloud-libs
-          path: kestra-ee/docker/app/libs
-
+      # Runs after the kestra-ee image push: the main Dockerfile COPYs the whole docker/
+      # tree, so cloud libs/plugins fetched earlier would leak into the public EE image.
       - name: Cloud - Build and push
         if: ${{ matrix.image.tag == '' && inputs.dry-run == false && github.event.client_payload.ref == '' && steps.cloud-ee.outputs.exists == 'true' }}
-        uses: docker/build-push-action@v6
+        uses: kestra-io/actions/composite/kestra-ee/cloud-image@main
         with:
-          context: kestra-ee/.
-          file: kestra-ee/Dockerfile.cloud
-          push: true
-          tags: ${{ env.CLOUD_GCP_IMAGE_PATH }}:${{ steps.vars.outputs.tag }}
-          platforms: linux/amd64,linux/arm64
-          network: host
-          build-args: |
-            BASE_IMAGE=${{ env.GITHUB_IMAGE_PATH }}:${{ steps.vars.outputs.tag }}
+          context: kestra-ee
+          base-image: ${{ env.GITHUB_IMAGE_PATH }}:${{ steps.vars.outputs.tag }}
+          image: ${{ env.CLOUD_GCP_IMAGE_PATH }}:${{ steps.vars.outputs.tag }}
+          kestra-version: ${{ github.ref_name }}
 
       - name: Setup - Install regctl
         if: startsWith(github.ref, 'refs/tags/v') && (inputs.dry-run == false)

--- a/composite/kestra-ee/cloud-image/action.yml
+++ b/composite/kestra-ee/cloud-image/action.yml
@@ -1,0 +1,46 @@
+name: Build Kestra Cloud image
+description: "Builds and pushes the kestra-cloud image: EE base image + cloud-ee libs + private cloud plugins (groupId io.kestra.plugin.cloud, resolved from the registry poms, never from the public plugin index)."
+
+inputs:
+  context:
+    description: "Directory of the kestra-ee checkout, used as the docker build context"
+    required: false
+    default: "kestra-ee"
+  base-image:
+    description: "Full ref of the kestra-ee image to build FROM"
+    required: true
+  image:
+    description: "Full target image ref (registry/path:tag)"
+    required: true
+  kestra-version:
+    description: "Kestra version being built (vX.Y.Z or a branch name), used to filter cloud plugins by core compatibility"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Download cloud plugins
+      shell: bash
+      env:
+        KESTRA_VERSION: ${{ inputs.kestra-version }}
+        PLUGINS_DIR: ${{ inputs.context }}/docker/app/cloud-plugins
+      run: |
+        chmod +x ${{ github.action_path }}/download-cloud-plugins.sh
+        ${{ github.action_path }}/download-cloud-plugins.sh
+
+    - name: Download cloud-ee libs
+      uses: actions/download-artifact@v5
+      with:
+        name: cloud-libs
+        path: ${{ inputs.context }}/docker/app/libs
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: ${{ inputs.context }}/.
+        file: ${{ inputs.context }}/Dockerfile.cloud
+        push: true
+        tags: ${{ inputs.image }}
+        platforms: linux/amd64,linux/arm64
+        network: host
+        build-args: |
+          BASE_IMAGE=${{ inputs.base-image }}

--- a/composite/kestra-ee/cloud-image/download-cloud-plugins.sh
+++ b/composite/kestra-ee/cloud-image/download-cloud-plugins.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Downloads the cloud-only plugins baked into the kestra-cloud image.
+#
+# Convention: every Maven package under the group "io.kestra.plugin.cloud" in the
+# private Artifact Registry is a cloud plugin. These plugins are deliberately never
+# indexed on api.kestra.io, so compatibility cannot be resolved through the plugin
+# API. It is read from the pom instead: the io.kestra:platform entry in
+# <dependencyManagement> is the plugin's kestraVersion at release time.
+#
+# For each plugin, the newest release compatible with KESTRA_VERSION is downloaded.
+#
+# ENV:
+#   KESTRA_VERSION  Kestra version being built ("v2.0.3", "2.0.3" or a branch name)
+#   PLUGINS_DIR     directory receiving the downloaded JARs
+#
+# Auth: ambient gcloud credentials (set up by google-github-actions/auth).
+set -euo pipefail
+
+readonly GROUP_ID="io.kestra.plugin.cloud"
+readonly GROUP_ID_AS_PATH="io/kestra/plugin/cloud"
+
+gcloud_artifacts() {
+    gcloud artifacts "$@" --project=kestra-host --location=europe-west1 --repository=maven
+}
+
+# is_lower_or_equal A B -> true when version A <= version B
+is_lower_or_equal() {
+    [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ]
+}
+
+# Prints the minimum Kestra version required by a plugin version, read from the
+# io.kestra:platform BOM entry of its pom. Prints nothing when the pom has none.
+minimum_kestra_version_of() {
+    local plugin="$1"
+    local version="$2"
+    local pom_directory minimum
+    pom_directory=$(mktemp -d)
+
+    gcloud_artifacts files download --quiet --destination="$pom_directory" \
+        "$GROUP_ID_AS_PATH/$plugin/$version/$plugin-$version.pom" > /dev/null
+
+    minimum=$(grep -A3 '<groupId>io.kestra</groupId>' "$pom_directory"/*.pom \
+        | grep -A2 '<artifactId>platform</artifactId>' \
+        | grep -oP '(?<=<version>)[^<]+' | head -1 | sed 's/-SNAPSHOT$//' || true)
+
+    rm -rf "$pom_directory"
+    echo "$minimum"
+}
+
+mkdir -p "$PLUGINS_DIR"
+
+# "v2.0.3" or "2.0.3-rc1" -> "2.0.3". A branch build (e.g. develop) has no
+# version to compare against: fall back to 999.999.999 ("infinitely recent",
+# same convention as kestractl resolveVersion) so every plugin version passes.
+kestra_version=$(echo "${KESTRA_VERSION#v}" | sed -E 's/-rc[0-9]+$//')
+if [[ ! "$kestra_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    kestra_version="999.999.999"
+fi
+
+# Two steps so a gcloud failure aborts the script (set -e) instead of being
+# swallowed by the grep and mistaken for "no cloud plugin in the registry".
+all_packages=$(gcloud_artifacts packages list --format='value(name)')
+cloud_plugins=$(echo "$all_packages" | grep "^${GROUP_ID}:" | cut -d: -f2 || true)
+
+if [ -z "$cloud_plugins" ]; then
+    echo "No package under group $GROUP_ID in the registry, nothing to download."
+    exit 0
+fi
+
+downloaded=0
+for plugin in $cloud_plugins; do
+    all_versions=$(gcloud_artifacts versions list --package="$GROUP_ID:$plugin" --format='value(name)')
+    releases_newest_first=$(echo "$all_versions" | grep -v -- '-SNAPSHOT' | sort --version-sort --reverse || true)
+
+    for version in $releases_newest_first; do
+        minimum_kestra_version=$(minimum_kestra_version_of "$plugin" "$version")
+
+        if [ -z "$minimum_kestra_version" ]; then
+            echo "::warning::$GROUP_ID:$plugin:$version has no io.kestra:platform in its pom, skipping this version"
+            continue
+        fi
+        if ! is_lower_or_equal "$minimum_kestra_version" "$kestra_version"; then
+            echo "$plugin $version requires Kestra >= $minimum_kestra_version: too recent for $kestra_version, trying an older version"
+            continue
+        fi
+
+        echo "$plugin -> $version (requires Kestra >= $minimum_kestra_version)"
+        gcloud_artifacts files download --quiet --destination="$PLUGINS_DIR" \
+            "$GROUP_ID_AS_PATH/$plugin/$version/$plugin-$version.jar" > /dev/null
+        # gcloud names the downloaded file after the URL-encoded full path:
+        # give it back its real name.
+        if [ ! -f "$PLUGINS_DIR/$plugin-$version.jar" ]; then
+            mv "$PLUGINS_DIR"/*"$plugin-$version.jar" "$PLUGINS_DIR/$plugin-$version.jar"
+        fi
+        downloaded=$((downloaded + 1))
+        break
+    done
+done
+
+if [ "$downloaded" -eq 0 ]; then
+    echo "::error::Cloud plugins exist under $GROUP_ID but none is compatible with Kestra $kestra_version, refusing to ship an empty cloud image."
+    exit 1
+fi
+
+echo "Downloaded cloud plugins:"
+ls -l "$PLUGINS_DIR"

--- a/composite/plugin-release-index/index-plugin-release.sh
+++ b/composite/plugin-release-index/index-plugin-release.sh
@@ -35,7 +35,14 @@ index() {
         fi
     fi
     GIT_COMMIT=$(git rev-parse --short HEAD)
-    
+
+    # Cloud plugins are private, shipped only in the kestra-cloud image: never index them.
+    # Checked before the semver guards so a cloud plugin skips cleanly whatever its versions.
+    if [[ "$GROUP" == io.kestra.plugin.cloud* ]]; then
+        echo "Cloud plugin $GROUP:$ARTIFACT ($VERSION): private, skipping release indexing."
+        return 0
+    fi
+
     semver_regex="^[0-9]+\.[0-9]+\.[0-9]+$"
     if [[ ! $VERSION =~ $semver_regex ]]; then
         echo "Error: Invalid pluginVersion '$VERSION'. Expected format MAJOR.MINOR.PATCH"


### PR DESCRIPTION
Ship private cloud plugins in the kestra-cloud image, without ever going through the public plugin index.

- New kestra-ee/cloud-image composite
- index-plugin-release.sh: plugins under the io.kestra.plugin.cloud group
are never indexed on api.kestra.io

Companion PR : https://github.com/kestra-io/kestra-ee/pull/9483