### PR TITLE
refactor(ci): centralize EE Maven proxy in a shared composite, close coverage gaps

### DIFF
--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -60,55 +60,10 @@ jobs:
           java-enabled: true
           java-version: ${{ inputs.java-version }}
 
-      # Route Gradle Maven reads through the GCP AR maven-remote caching proxy to avoid Maven
-      # Central HTTP 429 rate-limiting on shared runner IPs. Mirrors plugins.yml; no-op without a token.
-      - name: GCP - Check credentials availability
-        id: gcp-check
-        run: echo "available=${{ secrets.GCP_SERVICE_ACCOUNT != '' }}" >> $GITHUB_OUTPUT
-
-      - name: GCP - Auth with github service account
-        id: gcp-auth
-        uses: 'google-github-actions/auth@v3'
-        if: steps.gcp-check.outputs.available == 'true'
+      - name: Setup - Maven proxy
+        uses: kestra-io/actions/composite/kestra-ee/setup-maven-proxy@main
         with:
-          token_format: 'access_token'
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          export_environment_variables: false
-
-      - name: Setup - Gradle maven-remote init script
-        if: ${{ steps.gcp-auth.outputs.access_token != '' }}
-        shell: bash
-        run: |
-          mkdir -p ~/.gradle/init.d
-          cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
-          def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
-          def injectProxy = { repos ->
-              if (token && !repos.findByName("GcpMavenRemote")) {
-                  repos.maven {
-                      name = "GcpMavenRemote"
-                      url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
-                      credentials { username = "oauth2accesstoken"; password = token }
-                  }
-              }
-          }
-          // Always restore explicit repos: touching pluginManagement.repositories via beforeSettings
-          // drops the implicit gradlePluginPortal() default, so we re-add it unconditionally.
-          beforeSettings { settings ->
-              injectProxy(settings.pluginManagement.repositories)
-              if (!settings.pluginManagement.repositories.findByName("Gradle Plugin Portal")) {
-                  settings.pluginManagement.repositories.gradlePluginPortal()
-              }
-              if (!settings.pluginManagement.repositories.findByName("MavenRepo")) {
-                  settings.pluginManagement.repositories.mavenCentral()
-              }
-          }
-          if (token) {
-              allprojects {
-                  injectProxy(buildscript.repositories)
-                  injectProxy(repositories)
-              }
-          }
-          EOF
+          gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: OpenTelemetry - Setup
         uses: kestra-io/actions/actions/otel-collect@main
@@ -136,8 +91,6 @@ jobs:
 
       # Gradle check
       - name: Gradle - check and javadoc
-        env:
-          MAVEN_REMOTE_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
         run: |
           echo $GOOGLE_SERVICE_ACCOUNT | base64 -d > $(pwd)/.gcp-service-account.json
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.gcp-service-account.json

--- a/.github/workflows/kestra-ee-build-artifacts.yml
+++ b/.github/workflows/kestra-ee-build-artifacts.yml
@@ -54,55 +54,10 @@ jobs:
           node-enabled: 'true'
           java-version: ${{ inputs.java-version }}
 
-      # Route Gradle Maven reads through the GCP AR maven-remote caching proxy to avoid Maven
-      # Central HTTP 429 rate-limiting on shared runner IPs. Mirrors plugins.yml; no-op without a token.
-      - name: GCP - Check credentials availability
-        id: gcp-check
-        run: echo "available=${{ secrets.GCP_SERVICE_ACCOUNT != '' }}" >> $GITHUB_OUTPUT
-
-      - name: GCP - Auth with github service account
-        id: gcp-auth
-        uses: 'google-github-actions/auth@v3'
-        if: steps.gcp-check.outputs.available == 'true'
+      - name: Setup - Maven proxy
+        uses: kestra-io/actions/composite/kestra-ee/setup-maven-proxy@main
         with:
-          token_format: 'access_token'
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          export_environment_variables: false
-
-      - name: Setup - Gradle maven-remote init script
-        if: ${{ steps.gcp-auth.outputs.access_token != '' }}
-        shell: bash
-        run: |
-          mkdir -p ~/.gradle/init.d
-          cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
-          def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
-          def injectProxy = { repos ->
-              if (token && !repos.findByName("GcpMavenRemote")) {
-                  repos.maven {
-                      name = "GcpMavenRemote"
-                      url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
-                      credentials { username = "oauth2accesstoken"; password = token }
-                  }
-              }
-          }
-          // Always restore explicit repos: touching pluginManagement.repositories via beforeSettings
-          // drops the implicit gradlePluginPortal() default, so we re-add it unconditionally.
-          beforeSettings { settings ->
-              injectProxy(settings.pluginManagement.repositories)
-              if (!settings.pluginManagement.repositories.findByName("Gradle Plugin Portal")) {
-                  settings.pluginManagement.repositories.gradlePluginPortal()
-              }
-              if (!settings.pluginManagement.repositories.findByName("MavenRepo")) {
-                  settings.pluginManagement.repositories.mavenCentral()
-              }
-          }
-          if (token) {
-              allprojects {
-                  injectProxy(buildscript.repositories)
-                  injectProxy(repositories)
-              }
-          }
-          EOF
+          gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: OpenTelemetry - Setup
         uses: kestra-io/actions/actions/otel-collect@main
@@ -139,7 +94,6 @@ jobs:
       # Shadow Jar
       - name: Gradle - Build jars
         env:
-          MAVEN_REMOTE_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |

--- a/.github/workflows/kestra-ee-publish-docker.yml
+++ b/.github/workflows/kestra-ee-publish-docker.yml
@@ -100,6 +100,9 @@ jobs:
     uses: ./.github/workflows/kestra-ee-build-artifacts.yml
     secrets:
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+      # Routes the Build Jar Gradle step through the GCP AR maven-remote proxy to
+      # avoid Maven Central HTTP 429 on shared runner IPs. No-op if the secret is empty.
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       java-version: ${{ inputs.java-version }}

--- a/.github/workflows/kestra-ee-publish-maven.yml
+++ b/.github/workflows/kestra-ee-publish-maven.yml
@@ -41,6 +41,11 @@ jobs:
           node-enabled: 'true'
           java-version: ${{ inputs.java-version }}
 
+      - name: Setup - Maven proxy
+        uses: kestra-io/actions/composite/kestra-ee/setup-maven-proxy@main
+        with:
+          gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Setup - OpenTelemetry
         uses: kestra-io/actions/actions/otel-collect@main
         if: ${{ env.OTLP_ENDPOINT != '' }}

--- a/.github/workflows/kestra-ee-pullrequest-publish-docker.yml
+++ b/.github/workflows/kestra-ee-pullrequest-publish-docker.yml
@@ -5,6 +5,12 @@ on:
     secrets:
       GOOGLE_SERVICE_ACCOUNT:
         required: true
+      GCP_SERVICE_ACCOUNT:
+        description: "The GCP service account used to authenticate to the maven-remote Artifact Registry proxy."
+        required: false
+      CODECOV_TOKEN:
+        description: "The Codecov token."
+        required: false
     inputs:
       java-version:
         description: "Java version"
@@ -24,6 +30,9 @@ jobs:
     uses: ./.github/workflows/kestra-ee-build-artifacts.yml
     secrets:
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+      # Routes the Build Jar Gradle step through the GCP AR maven-remote proxy to
+      # avoid Maven Central HTTP 429 on shared runner IPs. No-op if the secret is empty.
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       java-version: ${{ inputs.java-version }}

--- a/composite/kestra-ee/setup-maven-proxy/action.yml
+++ b/composite/kestra-ee/setup-maven-proxy/action.yml
@@ -1,0 +1,73 @@
+name: 'Setup Maven proxy'
+description: >-
+  Routes Gradle Maven reads through the GCP Artifact Registry maven-remote caching proxy to
+  avoid Maven Central HTTP 429 rate-limiting on shared runner IPs. Writes a Gradle init script
+  and exports MAVEN_REMOTE_TOKEN to the whole job so every subsequent Gradle step is covered.
+  No-op when no service account is provided.
+
+inputs:
+  gcp-service-account:
+    description: >-
+      GCP service account JSON able to mint access tokens and read the maven-remote Artifact
+      Registry proxy. When empty, this action is a no-op and Gradle resolves from Maven Central.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: GCP - Check credentials availability
+      id: gcp-check
+      shell: bash
+      run: echo "available=${{ inputs.gcp-service-account != '' }}" >> "$GITHUB_OUTPUT"
+
+    - name: GCP - Auth with github service account
+      id: gcp-auth
+      if: steps.gcp-check.outputs.available == 'true'
+      uses: 'google-github-actions/auth@v3'
+      with:
+        token_format: 'access_token'
+        credentials_json: ${{ inputs.gcp-service-account }}
+        # Do not clobber GOOGLE_APPLICATION_CREDENTIALS: callers set it to a different
+        # (unit-test) service account for their own build/test steps.
+        export_environment_variables: false
+
+    - name: Setup - Gradle maven-remote init script
+      if: ${{ steps.gcp-auth.outputs.access_token != '' }}
+      shell: bash
+      env:
+        MAVEN_REMOTE_ACCESS_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
+      run: |
+        mkdir -p ~/.gradle/init.d
+        cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
+        def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
+        def injectProxy = { repos ->
+            if (token && !repos.findByName("GcpMavenRemote")) {
+                repos.maven {
+                    name = "GcpMavenRemote"
+                    url = "https://europe-maven.pkg.dev/kestra-host/maven-remote"
+                    credentials { username = "oauth2accesstoken"; password = token }
+                }
+            }
+        }
+        // Always restore explicit repos: touching pluginManagement.repositories via beforeSettings
+        // drops the implicit gradlePluginPortal() default, so we re-add it unconditionally.
+        beforeSettings { settings ->
+            injectProxy(settings.pluginManagement.repositories)
+            if (!settings.pluginManagement.repositories.findByName("Gradle Plugin Portal")) {
+                settings.pluginManagement.repositories.gradlePluginPortal()
+            }
+            if (!settings.pluginManagement.repositories.findByName("MavenRepo")) {
+                settings.pluginManagement.repositories.mavenCentral()
+            }
+        }
+        if (token) {
+            allprojects {
+                injectProxy(buildscript.repositories)
+                injectProxy(repositories)
+            }
+        }
+        EOF
+        # Export the token to the whole job so every subsequent Gradle step (build, sonar,
+        # publish, javadoc, ...) resolves through the proxy — not just one step's env.
+        echo "MAVEN_REMOTE_TOKEN=${MAVEN_REMOTE_ACCESS_TOKEN}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## What

Centralize the Maven-remote proxy (which avoids Maven Central HTTP 429 rate-limiting on shared runner IPs) into a single shared composite, and close the coverage gaps where EE Gradle work still resolved directly from `repo.maven.apache.org`.

## Why

The proxy was copy-pasted inline in `kestra-ee-backend-tests` and `kestra-ee-build-artifacts`, and missing entirely from several other Gradle-running paths. It was also opt-in per caller (gated on `GCP_SERVICE_ACCOUNT`), so any caller that didn't thread the secret silently no-opped and 429'd — e.g. the PR docker build's `Build Jar` step.

## Changes

- **New `composite/kestra-ee/setup-maven-proxy`** — auths, writes the Gradle init script, and exports `MAVEN_REMOTE_TOKEN` to the whole job (so *every* Gradle step is covered, not just one — this also fixes the `report-java` → `gradlew sonar` step, which previously ran unproxied).
- **`backend-tests` / `build-artifacts`** — replace the ~35-line inline block with the composite (net **−79 lines**).
- **`publish-maven`** — add the proxy. It ran `./gradlew publish` resolving from Central; the SA it received was only used to authenticate the publish, never to proxy dependency reads.
- **`publish-docker`** — forward `GCP_SERVICE_ACCOUNT` to the `build-artifacts` sub-job. It was dropped at the hop, so the release/develop `Build Jar` step ran unproxied.
- **`kestra-ee-pullrequest-publish-docker`** — declare + forward `GCP_SERVICE_ACCOUNT` and `CODECOV_TOKEN` (the latter was already forwarded to `build-artifacts` but never declared, so it always arrived empty).

## Merge order

Merge this **before** the companion kestra-ee PR — that PR references this composite and these reusable workflows at `@main`.

## Companion PR / issue

- Companion: kestra-io/kestra-ee (routes the direct-`gradlew` EE workflows through the new composite)
- Part of the durable fix for kestra-io/kestra-ee#9409
