### PR TITLE
fix(ci): install ui-ee with npm install so design-system deps resolve in EE check:types

### DIFF
--- a/.github/workflows/kestra-ee-frontend-tests.yml
+++ b/.github/workflows/kestra-ee-frontend-tests.yml
@@ -70,11 +70,16 @@ jobs:
           cd kestra/ui
           npm ci
 
+      # `npm install` (not `ci`), run unconditionally: the design-system/topology workspaces live in
+      # the OSS checkout, and their transitive deps (motion-v, mermaid, remark-*, moment-timezone)
+      # aren't captured in ui-ee/package-lock.json — so `npm ci` (strict lock) leaves them out of
+      # ui-ee/node_modules. With `preserveSymlinks: true`, vue-tsc resolves design-system's imports
+      # from the ui-ee tree, so they must be hoisted there. `npm install` reconciles the cross-repo
+      # workspaces and installs them, even when the EE node_modules cache was restored.
       - name: Npm - Install
-        if: steps.cache-ee-node-modules.outputs.cache-hit != 'true'
         shell: bash
         working-directory: kestra-ee/ui-ee
-        run: npm ci
+        run: npm install
 
       - name: Npm - Check types
         shell: bash


### PR DESCRIPTION
## Problem

`Frontend - Tests / Check → Npm - Check types` fails on `kestra-ee` PRs with a wall of `Cannot find module` errors inside `node_modules/@kestra-io/design-system/…` — `motion-v`, `mermaid`, `remark-parse`, `remark-gfm`, `moment-timezone`, and `monaco-editor/esm/vs/...`:

```
node_modules/@kestra-io/design-system/.../AdvancedFilterBuilder.vue: Cannot find module 'motion-v'
node_modules/@kestra-io/design-system/.../KsMarkdown.vue:            Cannot find module 'remark-gfm' / 'mermaid'
node_modules/@kestra-io/design-system/.../KsEditor.vue:              Cannot find module 'monaco-editor/esm/...'
node_modules/@kestra-io/design-system/.../date.ts:                   Cannot find module 'moment-timezone'
```

This is pre-existing (not tied to any one PR) and is the "vue-tsc symlink quirk" that's been floating around — the dev server runs fine, only `check:types` fails.

## Root cause

`ui-ee` consumes `@kestra-io/design-system` (and `topology`) as **cross-repo npm workspaces** pointing into the OSS checkout (`../../kestra/ui/packages/*`). Those packages' transitive deps (motion-v, mermaid, remark-\*, moment-timezone, and a compatible monaco-editor) are **not captured in `ui-ee/package-lock.json`**, so `npm ci` (strict lock) never installs them into `ui-ee/node_modules`.

Both OSS and EE set `preserveSymlinks: true`. In OSS that's fine — design-system is reached at its real path and resolves its deps from `kestra/ui/node_modules`. In EE, `vue-tsc` reaches design-system through the `ui-ee/node_modules/@kestra-io/design-system` symlink and, with `preserveSymlinks`, resolves its imports from the **ui-ee tree** — where those deps are absent. Hence the failures.

## Fix

Install `ui-ee` with `npm install` (reconcile) instead of `npm ci` (strict lock), and run it unconditionally so it also tops up a restored node_modules cache. `npm install` re-resolves the cross-repo workspaces and hoists design-system's full dependency closure into `ui-ee/node_modules`, which is what `preserveSymlinks` type-checking needs.

## Validation

Locally reproduced the failure, then symlinked the missing closure (at OSS-consistent versions) into `ui-ee/node_modules` and re-ran `npm run check:types` — it passes end-to-end:

```
design-system compiled
oss compiled
app checked
test checked
```

(Then reverted the local symlinks.) The `npm install` reconcile achieves the same population of `ui-ee/node_modules`.

## Notes / follow-up

- `npm install` may rewrite `ui-ee/package-lock.json` at CI time (harmless — discarded).
- The cleaner long-term fix is to **regenerate & commit `ui-ee/package-lock.json`** in `kestra-ee` so `npm ci` installs the closure; this workflow change unblocks CI in the meantime.
- Worth a CI run to confirm the reconcile lands `monaco-editor` at the OSS-consistent version.