### PR TITLE
feat(kestra-ee): route runtime plugin downloads through the maven proxy

### DIFF
--- a/composite/kestra-ee/setup-maven-proxy/action.yml
+++ b/composite/kestra-ee/setup-maven-proxy/action.yml
@@ -3,7 +3,8 @@ description: >-
   Routes Gradle Maven reads through the GCP Artifact Registry maven-remote caching proxy to
   avoid Maven Central HTTP 429 rate-limiting on shared runner IPs. Writes a Gradle init script
   and exports MAVEN_REMOTE_TOKEN to the whole job so every subsequent Gradle step is covered.
-  No-op when no service account is provided.
+  Also routes Kestra's runtime plugin downloader through the same proxy by exporting the
+  kestra.plugins.repositories.central.* overrides. No-op when no service account is provided.
 
 inputs:
   gcp-service-account:
@@ -71,3 +72,12 @@ runs:
         # Export the token to the whole job so every subsequent Gradle step (build, sonar,
         # publish, javadoc, ...) resolves through the proxy — not just one step's env.
         echo "MAVEN_REMOTE_TOKEN=${MAVEN_REMOTE_ACCESS_TOKEN}" >> "$GITHUB_ENV"
+        # Route Kestra's runtime plugin downloader (MavenPluginDownloader) through the same
+        # proxy. Micronaut binds these onto kestra.plugins.repositories.central.{url,basic-auth},
+        # overriding the Maven Central default that test/app configs ship with. This is CI-only:
+        # locally the token and these vars are absent, so configs keep resolving from Central.
+        {
+          echo "KESTRA_PLUGINS_REPOSITORIES_CENTRAL_URL=https://europe-maven.pkg.dev/kestra-host/maven-remote"
+          echo "KESTRA_PLUGINS_REPOSITORIES_CENTRAL_BASIC_AUTH_USERNAME=oauth2accesstoken"
+          echo "KESTRA_PLUGINS_REPOSITORIES_CENTRAL_BASIC_AUTH_PASSWORD=${MAVEN_REMOTE_ACCESS_TOKEN}"
+        } >> "$GITHUB_ENV"


### PR DESCRIPTION
## What

`setup-maven-proxy` only routed **Gradle build-time** dependency resolution through the GCP Artifact Registry proxy. Kestra's **runtime** plugin downloader (`MavenPluginDownloader`) resolves from the repositories declared in its own config (`kestra.plugins.repositories.*`), which default to Maven Central — so it was never covered.

Result: plugin-install tests such as `RemotePluginManagerTest` (fetching `io.kestra.plugin:plugin-serdes:0.21.0`) keep hitting Maven Central's HTTP 429 rate-limiting on shared runner IPs. This was the dominant cause of red `develop` runs in kestra-ee (~40/92 recent runs).

## How

When the GCP token is present, export the Micronaut overrides to the job env:

```
KESTRA_PLUGINS_REPOSITORIES_CENTRAL_URL=https://europe-maven.pkg.dev/kestra-host/maven-remote
KESTRA_PLUGINS_REPOSITORIES_CENTRAL_BASIC_AUTH_USERNAME=oauth2accesstoken
KESTRA_PLUGINS_REPOSITORIES_CENTRAL_BASIC_AUTH_PASSWORD=$MAVEN_REMOTE_TOKEN
```

These bind onto `kestra.plugins.repositories.central.{url,basic-auth}`, overriding the Maven Central default that app/test configs ship with, so the runtime downloader resolves through the same cached proxy.

**CI-only by construction:** locally the token (and therefore these vars) are absent, so configs keep resolving straight from Central — no local-dev impact, no config file changes needed.

## Notes
- Chosen over a per-repo `application-*.yml` change so it transparently covers every repo using this composite, in the same place the Gradle proxy injection already lives.
- Companion PR: kestra-io/kestra #(SearchableFactory log-level fix) — unrelated cause, same red develop.