### PR TITLE
fix(ci): route EE Gradle Maven reads through GCP proxy, drop Central + Sonatype

### DIFF
--- a/.github/workflows/kestra-ee-e2e-tests.yml
+++ b/.github/workflows/kestra-ee-e2e-tests.yml
@@ -8,6 +8,9 @@ on:
       APPLICATION_SECRETS:
         description: "applications-secrets.yml with license infos for EE Kestra, encoded as base64"
         required: true
+      GCP_SERVICE_ACCOUNT:
+        description: "GCP service account JSON for the Maven proxy (routes Gradle reads off Maven Central). Optional; when absent the proxy step is a no-op."
+        required: false
     inputs:
       noInputYet:
         description: 'not input yet.'
@@ -52,6 +55,11 @@ jobs:
           java-enabled: 'true'
           node-enabled: 'true'
           java-version: ${{ inputs.java-version }}
+
+      - name: Setup - Maven proxy
+        uses: kestra-io/actions/composite/kestra-ee/setup-maven-proxy@main
+        with:
+          gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Setup - OpenTelemetry
         uses: kestra-io/actions/actions/otel-collect@main

--- a/composite/kestra-ee/setup-maven-proxy/action.yml
+++ b/composite/kestra-ee/setup-maven-proxy/action.yml
@@ -42,6 +42,12 @@ runs:
         mkdir -p ~/.gradle/init.d
         cat > ~/.gradle/init.d/maven-remote.gradle << 'EOF'
         def token = System.getenv("MAVEN_REMOTE_TOKEN") ?: ""
+
+        // The GCP Artifact Registry "maven-remote" is a server-side caching mirror of Maven
+        // Central: requests are proxied from Google IPs, never the shared runner IP, so it is
+        // immune to the Maven Central HTTP 429 rate-limiting that fails CI plugin/dependency
+        // resolution. Route ALL Gradle Maven reads through it and stop touching raw Maven
+        // Central (repo.maven.apache.org) and Sonatype (central.sonatype.com) entirely.
         def injectProxy = { repos ->
             if (token && !repos.findByName("GcpMavenRemote")) {
                 repos.maven {
@@ -51,21 +57,60 @@ runs:
                 }
             }
         }
-        // Always restore explicit repos: touching pluginManagement.repositories via beforeSettings
-        // drops the implicit gradlePluginPortal() default, so we re-add it unconditionally.
+
+        // Neutralise raw public repos (Maven Central + Sonatype) wherever they are declared,
+        // including ones added later by build scripts. We disable them via content filtering
+        // rather than removing them: removal races with the root buildscript block, whereas an
+        // "all {}" hook + excludeGroupByRegex is order- and timing-independent. An excluded repo
+        // is never queried; the proxy (a Central mirror) serves the same content.
+        def isRawPublic = { repo ->
+            repo instanceof org.gradle.api.artifacts.repositories.MavenArtifactRepository &&
+                repo.url != null &&
+                (repo.url.toString().startsWith("https://repo.maven.apache.org") ||
+                 repo.url.toString().contains("central.sonatype.com"))
+        }
+        // Plugin/buildscript repos: neutralise raw Central/Sonatype, and for the remaining maven
+        // repos use the .pom only + ignore the .module redirect. Some plugins (artifactregistry,
+        // owasp dependencycheck) publish Gradle Module Metadata whose .module the proxy does not
+        // mirror and the Plugin Portal lacks, so Gradle would chase the .module back to Central and
+        // 429. The Portal's .pom resolves them.
+        def scrubPluginRepos = { repos ->
+            repos.all { repo ->
+                if (isRawPublic(repo)) {
+                    repo.content { excludeGroupByRegex ".*" }
+                } else if (repo instanceof org.gradle.api.artifacts.repositories.MavenArtifactRepository) {
+                    repo.metadataSources { mavenPom(); ignoreGradleMetadataRedirection() }
+                }
+            }
+        }
+        // Project (main-dependency) repos: only neutralise raw Central/Sonatype. Keep Gradle Module
+        // Metadata so library variant/capability resolution stays correct — the proxy mirrors the
+        // .module for normal Central-hosted libraries.
+        def scrubDependencyRepos = { repos ->
+            repos.all { repo ->
+                if (isRawPublic(repo)) {
+                    repo.content { excludeGroupByRegex ".*" }
+                }
+            }
+        }
+
         beforeSettings { settings ->
             injectProxy(settings.pluginManagement.repositories)
-            if (!settings.pluginManagement.repositories.findByName("Gradle Plugin Portal")) {
+            // Keep the Gradle Plugin Portal for plugin markers/impls not mirrored by Central.
+            // (Touching pluginManagement.repositories drops the implicit default; its real name
+            // is "Gradle Central Plugin Repository".)
+            if (!settings.pluginManagement.repositories.findByName("Gradle Central Plugin Repository")) {
                 settings.pluginManagement.repositories.gradlePluginPortal()
             }
-            if (!settings.pluginManagement.repositories.findByName("MavenRepo")) {
-                settings.pluginManagement.repositories.mavenCentral()
-            }
+            // Intentionally NO mavenCentral() here — neutralise it if a settings script adds one.
+            scrubPluginRepos(settings.pluginManagement.repositories)
         }
         if (token) {
             allprojects {
                 injectProxy(buildscript.repositories)
+                scrubPluginRepos(buildscript.repositories)
                 injectProxy(repositories)
+                scrubDependencyRepos(repositories)
             }
         }
         EOF


### PR DESCRIPTION
## Problem
Shared GitHub-runner IPs get **HTTP 429 (Too Many Requests)** from Maven Central, failing EE builds during Gradle **plugin/dependency resolution** (e.g. `com.adarshr.test-logger.gradle.plugin`). This has been breaking many EE PRs.

## Fix (all in the `setup-maven-proxy` composite)
Route **all** Gradle Maven reads through the GCP Artifact Registry `maven-remote` mirror (proxied from Google IPs, immune to Central's per-IP 429) and stop touching raw Maven Central / Sonatype entirely:
- **Content-filter** (`excludeGroupByRegex`) neutralises raw `repo.maven.apache.org` + `central.sonatype.com` in `pluginManagement`, `buildscript` and project repositories. Content filtering flags the repo object (honoured at resolution time) — order/timing-independent, unlike removal which races the root buildscript block.
- **`ignoreGradleMetadataRedirection`** on plugin/buildscript repos: `artifactregistry` + `owasp dependencycheck` publish Gradle Module Metadata whose `.module` the proxy doesn't mirror and the Portal lacks, so Gradle would chase it back to Central and 429. Project-dependency repos keep Module Metadata (variant resolution stays correct).
- Keep the **Gradle Plugin Portal**; **no** raw `mavenCentral()` fallback.

Also wires `setup-maven-proxy` into **`kestra-ee-e2e-tests.yml`** (new optional `GCP_SERVICE_ACCOUNT` secret) so the E2E Gradle build is covered too.

## Safety
When no service account is provided the whole init script is skipped (token-gated), so jobs that don't pass the SA behave exactly as today — never worse.

## Validation
End-to-end on a kestra-ee sandbox (all EE source reverted to develop, so the fix is composite-only): **Build Jar** and **E2E** both green, **0 requests to `repo.maven.apache.org`, 0 `429`s**.

## Companion
kestra-ee `pull-request.yml` needs `GCP_SERVICE_ACCOUNT` passed to the e2e-tests job — companion PR follows (merge **after** this one, since it relies on the new secret input landing on `main`).