### PR TITLE
feat: report failing UI tests as a PR comment

### DIFF
--- a/.github/workflows/kestra-ee-frontend-tests.yml
+++ b/.github/workflows/kestra-ee-frontend-tests.yml
@@ -110,12 +110,10 @@ jobs:
         run: npm run test:storybook -- --coverage
 
       # Runs on success too (not just failure): that's what lets it clear a
-      # stale failures comment once the suite goes back to green. Pinned to
-      # a kestra ref, not this repo, since the action's implementation lives
-      # in kestra-io/kestra alongside the vitest config it depends on.
+      # stale failures comment once the suite goes back to green.
       - name: Report failing UI tests on the PR
         if: always()
-        uses: kestra-io/kestra/.github/actions/report-ui-test-failures@develop
+        uses: kestra-io/actions/composite/report-ui-test-failures@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           base-path: kestra-ee/ui-ee

--- a/.github/workflows/kestra-ee-frontend-tests.yml
+++ b/.github/workflows/kestra-ee-frontend-tests.yml
@@ -108,3 +108,17 @@ jobs:
         shell: bash
         working-directory: kestra-ee/ui-ee
         run: npm run test:storybook -- --coverage
+
+      # Runs on success too (not just failure): that's what lets it clear a
+      # stale failures comment once the suite goes back to green. Pinned to
+      # a kestra ref, not this repo, since the action's implementation lives
+      # in kestra-io/kestra alongside the vitest config it depends on.
+      - name: Report failing UI tests on the PR
+        if: always()
+        uses: kestra-io/kestra/.github/actions/report-ui-test-failures@develop
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          base-path: kestra-ee/ui-ee
+          repo-path: ui-ee
+          unit-report-path: kestra-ee/ui-ee/test-report.junit.xml
+          storybook-report-path: kestra-ee/ui-ee/test-report.storybook.junit.xml

--- a/.github/workflows/kestra-oss-frontend-tests.yml
+++ b/.github/workflows/kestra-oss-frontend-tests.yml
@@ -96,11 +96,9 @@ jobs:
         run: npm run test:storybook -- --coverage
 
       # Runs on success too (not just failure): that's what lets it clear a
-      # stale failures comment once the suite goes back to green. Pinned to
-      # a kestra ref, not this repo, since the action's implementation lives
-      # in kestra-io/kestra alongside the vitest config it depends on.
+      # stale failures comment once the suite goes back to green.
       - name: Report failing UI tests on the PR
         if: always()
-        uses: kestra-io/kestra/.github/actions/report-ui-test-failures@develop
+        uses: kestra-io/actions/composite/report-ui-test-failures@main
         with:
           github-token: ${{ secrets.GITHUB_AUTH_TOKEN }}

--- a/.github/workflows/kestra-oss-frontend-tests.yml
+++ b/.github/workflows/kestra-oss-frontend-tests.yml
@@ -94,3 +94,13 @@ jobs:
       - name: Run storybook component tests
         working-directory: ui
         run: npm run test:storybook -- --coverage
+
+      # Runs on success too (not just failure): that's what lets it clear a
+      # stale failures comment once the suite goes back to green. Pinned to
+      # a kestra ref, not this repo, since the action's implementation lives
+      # in kestra-io/kestra alongside the vitest config it depends on.
+      - name: Report failing UI tests on the PR
+        if: always()
+        uses: kestra-io/kestra/.github/actions/report-ui-test-failures@develop
+        with:
+          github-token: ${{ secrets.GITHUB_AUTH_TOKEN }}

--- a/composite/report-ui-test-failures/action.yml
+++ b/composite/report-ui-test-failures/action.yml
@@ -7,6 +7,10 @@ description: >-
   a link to the test source on GitHub); when more failed, adds the total
   count and a link to the run above the list. Call with `if: always()` after
   the test steps so a run that goes back to green removes the stale comment.
+  Safe to call from any branch/version: a report path that doesn't exist is
+  treated as zero failures, never an error, since this action runs (pinned
+  to @main) across every release branch and older ones may not produce a
+  given report at all.
 
 inputs:
   github-token:

--- a/composite/report-ui-test-failures/action.yml
+++ b/composite/report-ui-test-failures/action.yml
@@ -1,0 +1,74 @@
+name: "Report UI test failures"
+description: >-
+  Parse the Vitest JUnit reports for the unit and Storybook test projects and
+  post (or update) a single PR comment listing the failing tests, so a UI
+  test failure doesn't require digging through CI logs to find what broke.
+  Lists up to `max-listed-failures` failing tests (name, category, error, and
+  a link to the test source on GitHub); when more failed, adds the total
+  count and a link to the run above the list. Call with `if: always()` after
+  the test steps so a run that goes back to green removes the stale comment.
+
+inputs:
+  github-token:
+    description: "Token with pull-requests: write permission on this repo."
+    required: true
+  base-path:
+    description: >-
+      Directory the test projects run from, relative to the job's working
+      directory — used to find source files on disk (e.g. 'ui', or
+      'kestra-ee/ui-ee' when this repo is checked out into a subdirectory
+      alongside another one).
+    required: false
+    default: "ui"
+  repo-path:
+    description: >-
+      Same directory, but relative to THIS repo's own root — used to build
+      GitHub source links. Only differs from base-path when the checkout
+      path isn't the repo root (e.g. base-path 'kestra-ee/ui-ee' but
+      repo-path 'ui-ee', since ui-ee is at the root of the kestra-ee repo).
+      Defaults to base-path.
+    required: false
+    default: ""
+  unit-report-path:
+    description: "Repo-relative path to the unit tests JUnit XML report."
+    required: false
+    default: "ui/test-report.junit.xml"
+  storybook-report-path:
+    description: "Repo-relative path to the Storybook tests JUnit XML report."
+    required: false
+    default: "ui/test-report.storybook.junit.xml"
+  max-listed-failures:
+    description: "Maximum number of failing tests to list individually before trimming to a count + run link."
+    required: false
+    default: "5"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Post or update UI test failures comment"
+      uses: actions/github-script@v9
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        BASE_PATH: ${{ inputs.base-path }}
+        REPO_PATH: ${{ inputs.repo-path }}
+        UNIT_REPORT_PATH: ${{ inputs.unit-report-path }}
+        STORYBOOK_REPORT_PATH: ${{ inputs.storybook-report-path }}
+        MAX_LISTED_FAILURES: ${{ inputs.max-listed-failures }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const path = require("path")
+          const {run} = require(path.join(process.env.ACTION_PATH, "report-failures.js"))
+
+          await run({
+            github,
+            context,
+            core,
+            basePath: process.env.BASE_PATH,
+            repoPath: process.env.REPO_PATH,
+            maxListedFailures: Number(process.env.MAX_LISTED_FAILURES),
+            reports: [
+              {path: process.env.UNIT_REPORT_PATH, category: "Unit test"},
+              {path: process.env.STORYBOOK_REPORT_PATH, category: "Storybook test"},
+            ],
+          })

--- a/composite/report-ui-test-failures/report-failures.js
+++ b/composite/report-ui-test-failures/report-failures.js
@@ -150,6 +150,10 @@ async function run({github, context, core, basePath, repoPath, reports, maxListe
         return
     }
 
+    // A missing report is treated as "no failures", never an error: this
+    // action is shared (called with @main) across every release branch, and
+    // older ones won't have a given project's JUnit reporter configured —
+    // or the project itself — so its report file will never exist there.
     const failures = reports.flatMap(({path: reportPath, category}) => {
         if (!reportPath || !fs.existsSync(reportPath)) return []
         return parseJUnitFailures(fs.readFileSync(reportPath, "utf8"), category)

--- a/composite/report-ui-test-failures/report-failures.js
+++ b/composite/report-ui-test-failures/report-failures.js
@@ -1,0 +1,166 @@
+const fs = require("fs")
+
+const COMMENT_MARKER = "<!-- kestra:ui-test-failures-report -->"
+
+function decodeXmlEntities(value) {
+    return value
+        .replace(/&quot;/g, "\"")
+        .replace(/&apos;/g, "'")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&amp;/g, "&")
+}
+
+function extractAttribute(tag, attribute) {
+    // `\b` (not just a plain match) matters here: "classname" contains "name"
+    // as a substring, and a bare `name="..."` pattern would match inside it.
+    const match = tag.match(new RegExp(`\\b${attribute}="([^"]*)"`))
+    return match ? decodeXmlEntities(match[1]) : undefined
+}
+
+// Vitest's built-in "junit" reporter output is flat enough (testsuite >
+// testcase > failure|error, all attributes on the opening tag) for a small
+// regex parser — pulling in a full XML library for this would be overkill.
+function parseJUnitFailures(xml, category) {
+    const failures = []
+    const testsuiteBlocks = xml.match(/<testsuite\b[^>]*>[\s\S]*?<\/testsuite>/g) ?? []
+
+    for (const suiteBlock of testsuiteBlocks) {
+        const file = extractAttribute(suiteBlock.match(/<testsuite\b[^>]*>/)[0], "name")
+        const testcaseBlocks = suiteBlock.match(/<testcase\b[^>]*?(?:\/>|>[\s\S]*?<\/testcase>)/g) ?? []
+
+        for (const testcaseBlock of testcaseBlocks) {
+            const failureBlock = testcaseBlock.match(/<(failure|error)\b[^>]*?(?:\/>|>[\s\S]*?<\/\1>)/)
+            if (!failureBlock) continue
+
+            const testcaseOpenTag = testcaseBlock.match(/<testcase\b[^>]*>/)?.[0] ?? testcaseBlock
+            failures.push({
+                category,
+                file,
+                name: extractAttribute(testcaseOpenTag, "name"),
+                message: extractAttribute(failureBlock[0], "message") ?? "See the CI logs for details.",
+            })
+        }
+    }
+
+    return failures
+}
+
+// Best-effort: point the link at the exact `it(`/`test(` line when we can
+// find it in the checked-out source, otherwise fall back to the file itself.
+function findLineNumber(repoRelativePath, testName) {
+    if (!fs.existsSync(repoRelativePath)) return undefined
+
+    const lastSegment = testName?.split(" > ").pop()
+    if (!lastSegment) return undefined
+
+    const lines = fs.readFileSync(repoRelativePath, "utf8").split("\n")
+    const index = lines.findIndex((line) => line.includes(lastSegment))
+    return index === -1 ? undefined : index + 1
+}
+
+function buildCommentBody({failures, repository, sha, basePath, repoPath, runUrl, maxListedFailures}) {
+    if (failures.length === 0) return null
+
+    const listed = failures.slice(0, maxListedFailures)
+    const lines = [
+        COMMENT_MARKER,
+        `### :x: ${failures.length} UI test${failures.length > 1 ? "s" : ""} failed`,
+    ]
+
+    if (failures.length > maxListedFailures) {
+        lines.push(
+            "",
+            `Showing the first ${maxListedFailures} below — see the [full run](${runUrl}) for all ${failures.length} failures.`,
+        )
+    }
+
+    for (const failure of listed) {
+        // These two differ when the job checks out this repo into a
+        // subdirectory alongside another one (e.g. the EE frontend job
+        // checks kestra-ee out under "kestra-ee/"): `basePath` is where to
+        // find the file on disk, `repoPath` is where it lives in the repo
+        // itself, which is what a GitHub blob URL must be relative to.
+        const diskPath = `${basePath}/${failure.file}`
+        const repoRelativePath = `${repoPath}/${failure.file}`
+        const line = findLineNumber(diskPath, failure.name)
+        const url = `https://github.com/${repository}/blob/${sha}/${repoRelativePath}${line ? `#L${line}` : ""}`
+
+        lines.push(
+            "",
+            `#### \`${failure.name}\``,
+            `- **Category:** ${failure.category}`,
+            `- **Test:** [${repoRelativePath}](${url})`,
+            "- **Error:**",
+            "  ```",
+            `  ${failure.message}`,
+            "  ```",
+        )
+    }
+
+    return lines.join("\n")
+}
+
+async function findExistingCommentId({github, context}) {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+    })
+    return comments.find((comment) => comment.body?.includes(COMMENT_MARKER))?.id
+}
+
+async function upsertComment({github, context, core, body}) {
+    const existingId = await findExistingCommentId({github, context})
+
+    if (!body) {
+        if (existingId) {
+            await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingId,
+            })
+            core.info("No UI test failures — removed the stale failures comment.")
+        } else {
+            core.info("No UI test failures — nothing to report.")
+        }
+        return
+    }
+
+    if (existingId) {
+        await github.rest.issues.updateComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: existingId,
+            body,
+        })
+    } else {
+        await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            body,
+        })
+    }
+}
+
+async function run({github, context, core, basePath, repoPath, reports, maxListedFailures}) {
+    if (!context.payload.pull_request) {
+        core.info("Not running on a pull request — skipping UI test failure report.")
+        return
+    }
+
+    const failures = reports.flatMap(({path: reportPath, category}) => {
+        if (!reportPath || !fs.existsSync(reportPath)) return []
+        return parseJUnitFailures(fs.readFileSync(reportPath, "utf8"), category)
+    })
+
+    const repository = `${context.repo.owner}/${context.repo.repo}`
+    const sha = context.payload.pull_request.head.sha
+    const runUrl = `${context.serverUrl}/${repository}/actions/runs/${context.runId}`
+
+    const body = buildCommentBody({failures, repository, sha, basePath, repoPath: repoPath || basePath, runUrl, maxListedFailures})
+    await upsertComment({github, context, core, body})
+}
+
+module.exports = {run}


### PR DESCRIPTION
Adds a composite action (`composite/report-ui-test-failures`) that parses unit/storybook Vitest JUnit reports and posts a PR comment listing failing tests, or a count + run link when more than 5 fail.
Wires it into both the OSS and EE frontend test jobs, right after their existing test steps.
No cross-repo dependency: the storybook JUnit reporter in `kestra-io/kestra#17668` improves what it can report, but isn't required to merge first.