### PR TITLE
fix(plugins): pass MAVEN_REMOTE_TOKEN to the publish step so it uses the mirror

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -298,6 +298,11 @@ jobs:
       - name: Publish - Java
         uses: kestra-io/actions/composite/publish-java@main
         if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && startsWith(github.repository, 'kestra-io/') && steps.publish-guard.outputs.should-publish == 'true' }}
+        # Same as the Gradle check step: the maven-remote init script reads MAVEN_REMOTE_TOKEN to
+        # route the publish build's dependency reads (incl. the OpenTelemetry init script classpath)
+        # through the GCP mirror instead of Maven Central, which 429s on shared runner IPs.
+        env:
+          MAVEN_REMOTE_TOKEN: ${{ steps.gcp-auth.outputs.access_token }}
         with:
           secrets: ${{ toJSON(secrets) }}
           is-private: ${{ inputs.sonatype-publish == false }}


### PR DESCRIPTION
Follow-up to #164: the token was only on the Gradle check step, so the publish build resolved OpenTelemetry/gRPC from Maven Central and 429'd. Set the same token env on the Publish - Java step so publish also routes through the mirror.