### PR TITLE
fix(publish-java): retry private publish on transient registry errors

### DIFF
--- a/composite/publish-java/action.yml
+++ b/composite/publish-java/action.yml
@@ -34,19 +34,37 @@ runs:
           -Dorg.gradle.internal.repository.max.retries=8
           -Dorg.gradle.internal.repository.initial.backoff=1000
       run: |
-        set +e
-        ./gradlew publish --no-daemon --no-parallel --max-workers=1 --stacktrace 2>&1 | tee /tmp/publish.log
-        exit_code=${PIPESTATUS[0]}
-        set -e
+        max_attempts=4
+        for attempt in $(seq 1 "$max_attempts"); do
+          set +e
+          ./gradlew publish --no-daemon --no-parallel --max-workers=1 --stacktrace 2>&1 | tee /tmp/publish.log
+          exit_code=${PIPESTATUS[0]}
+          set -e
 
-        if [ "$exit_code" -ne 0 ]; then
+          if [ "$exit_code" -eq 0 ]; then
+            exit 0
+          fi
+
           # Tolerate duplicate-version rejection on retries; other failures still surface.
           if grep -q "Component with package url.*already exists" /tmp/publish.log; then
             echo "::warning::Already published; skipping."
             exit 0
           fi
+
+          # Artifact Registry rejects a snapshot upload with a bare 400 when another build is
+          # writing the same SNAPSHOT coordinates at that moment — e.g. several PRs merged to
+          # main within seconds, each publishing the same x.y.z-SNAPSHOT. Gradle's own
+          # repository retries (max.retries above) do not cover 4xx, so back off here instead.
+          # A genuinely malformed request fails identically on every attempt and still surfaces.
+          if [ "$attempt" -lt "$max_attempts" ] && grep -qE "Received status code (400|429|5[0-9]{2})" /tmp/publish.log; then
+            backoff=$(( (2 ** attempt) * 15 + RANDOM % 15 ))
+            echo "::warning::Publish failed with a transient status code, retrying in ${backoff}s (attempt ${attempt}/${max_attempts})."
+            sleep "$backoff"
+            continue
+          fi
+
           exit "$exit_code"
-        fi
+        done
 
     - name: Publish - Release package to Maven Central
       if: ${{ inputs.is-private == 'false' }}


### PR DESCRIPTION
## Problem

A green build can still fail the whole `Main` job on a publish race.

Artifact Registry answers a snapshot upload with a bare `HTTP 400 Bad Request` when another build is writing the **same** SNAPSHOT coordinates at that moment. This happens whenever several PRs are merged in quick succession: each push starts its own `Main` run, and they all publish the same `x.y.z-SNAPSHOT` within seconds of each other, so one of them loses the race.

Observed in [kestra-io/secret-delinea run 30545875307](https://github.com/kestra-io/secret-delinea/actions/runs/30545875307) — three dependabot merges landed 17 seconds apart:

| Run | Publish attempt | Result |
|---|---|---|
| 30545864393 | 13:19:37 | ✅ |
| **30545875307** | **13:19:19** | **❌ 400** |
| 30545885790 | 13:19:37 | ✅ |

```
> Task :publishMavenPublicationToMavenRepository FAILED
  Could not PUT '…/maven-snapshot/…/secret-delinea-1.2.2-20260730.131919-22.jar'.
  Received status code 400 from server: Bad Request
```

Tests were fully green (27/27); only the publish step failed, which also fired a Slack CI-failure alert for a non-issue.

## Fix

`org.gradle.internal.repository.max.retries` (already set on this step) only covers network-level failures, not 4xx — so Gradle never retried. The publish invocation is now wrapped in a bounded retry with exponential backoff and jitter, mirroring the Maven Central loop directly below it in the same file.

- 4 attempts, backoff ~30s / ~60s / ~120s (+ jitter), so worst case adds ~3.5 min before a real failure surfaces.
- Retries only on `Received status code 400|429|5xx`; every other failure exits immediately as before.
- The `Component with package url … already exists` short-circuit is unchanged.
- A genuinely malformed request fails identically on every attempt and still surfaces — retrying cannot mask it.

## Testing

Ran the step's script against a stubbed `gradlew`:

- transient 400 then success → retries, exits `0` on attempt 3
- persistent 400 → 4 attempts, exits `1`
- `already exists` → exits `0` immediately, no retry

## Follow-up (not in this PR)

Neither `.github/workflows/plugins.yml` nor the caller workflows declare a `concurrency` group, so nothing serializes publishes on `main`. Adding one would remove the race at the source rather than absorbing it, at the cost of queueing full ~8 min jobs. Happy to open that separately if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
