### PR TITLE
feat(workflows): parallelize the OSS frontend CI and reuse the PR build for E2E

### DIFF
--- a/.github/workflows/kestra-oss-designsystem-tests.yml
+++ b/.github/workflows/kestra-oss-designsystem-tests.yml
@@ -16,14 +16,13 @@ jobs:
   test:
     name: Frontend - Design System Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22.18.0'
+      - name: Setup - Frontend
+        uses: kestra-io/actions/composite/setup-frontend@main
 
       - name: Setup - OpenTelemetry
         uses: kestra-io/actions/actions/otel-collect@main
@@ -35,40 +34,29 @@ jobs:
           host-metrics-enabled: 'true'
           service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"
 
-      - name: Cache Node Modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ui/node_modules
-          key: modules-${{ hashFiles('ui/package-lock.json') }}
-
+      # Same key as the frontend storybook job on purpose: both install
+      # exactly chromium, so a hit from either is complete for the other.
       - name: Cache Playwright Binaries
         id: cache-playwright
         uses: actions/cache@v4
         with:
           path: |
             ~/.cache/ms-playwright
-          key: playwright-${{ hashFiles('ui/package-lock.json') }}
+          key: playwright-chromium-${{ hashFiles('ui/package-lock.json') }}
 
-      - name: Npm - install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        working-directory: ui
-        run: npm ci
-    
       - name: Npm - check types
         working-directory: ui/packages/design-system
         run: npm run types:test
 
       - name: Run front-end unit tests
         working-directory: ui/packages/design-system
-        run: npm run unit:test -- --coverage
+        run: npm run unit:test
 
       - name: Storybook - Install Playwright
         working-directory: ui/packages/design-system
         if: steps.cache-playwright.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
 
       - name: Run storybook component tests
         working-directory: ui/packages/design-system
-        run: npm run storybook:test -- --coverage
+        run: npm run storybook:test

--- a/.github/workflows/kestra-oss-e2e-tests.yml
+++ b/.github/workflows/kestra-oss-e2e-tests.yml
@@ -13,6 +13,15 @@ on:
         type: string
         default: '21'
         required: false
+      exe-artifact:
+        description: >-
+          Name of a Kestra executable artifact already uploaded by this workflow
+          run (e.g. `exe` from Build Artifacts). When set, the Docker image under
+          test is built from it instead of rebuilding the product from source;
+          leave empty (forks, scheduled runs) to build from source.
+        type: string
+        default: ''
+        required: false
 
 env:
   OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
@@ -34,14 +43,15 @@ jobs:
         with:
           path: kestra
 
-      # Setup build
+      # Setup build. Java/python only exist to build the product from source,
+      # so both are skipped when a prebuilt executable artifact is provided.
       - uses: kestra-io/actions/composite/setup-build@main
         name: Setup - Build
         id: build
         with:
-          java-enabled: true
+          java-enabled: ${{ inputs.exe-artifact == '' && 'true' || 'false' }}
           node-enabled: true
-          python-enabled: true
+          python-enabled: ${{ inputs.exe-artifact == '' && 'true' || 'false' }}
           java-version: ${{ inputs.java-version }}
 
       - name: Setup - OpenTelemetry
@@ -55,21 +65,46 @@ jobs:
           gradle-tracing-enabled: 'true'
           service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"
 
+      # Same content-addressed key as the frontend jobs: the browser cache path
+      # is absolute (~/.cache/ms-playwright) and both install exactly chromium.
       - name: Cache - Playwright Binaries
         id: cache-playwright
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ hashFiles('kestra/ui/package-lock.json') }}
+          key: playwright-chromium-${{ hashFiles('kestra/ui/package-lock.json') }}
+
+      # Key is namespaced (`-e2e-`): this checkout lives under kestra/, and a
+      # cache archive saved from ui/ would restore to the wrong directory here.
+      - name: Cache - Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            kestra/ui/node_modules
+            kestra/ui/packages/*/node_modules
+            !kestra/ui/node_modules/.tmp
+            !kestra/ui/packages/*/node_modules/.tmp
+          key: modules-e2e-v2-${{ hashFiles('kestra/ui/package-lock.json', 'kestra/ui/patches/**') }}
 
       - name: Install Npm dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: cd kestra/ui && npm ci
 
       - name: Install Playwright
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         run: cd kestra/ui && npx playwright install --with-deps chromium
 
+      - name: Artifacts - Download executable
+        if: ${{ inputs.exe-artifact != '' }}
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ inputs.exe-artifact }}
+          path: kestra/build/executable
+
       - name: Run E2E Tests
+        env:
+          E2E_USE_PREBUILT_EXE: ${{ inputs.exe-artifact != '' }}
         run: |
           cd kestra
           sh build-and-start-e2e-tests.sh

--- a/.github/workflows/kestra-oss-frontend-tests.yml
+++ b/.github/workflows/kestra-oss-frontend-tests.yml
@@ -125,12 +125,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # This workflow is pinned @main and also runs for release branches whose
+      # test:storybook predates SHARD support (there it runs the whole suite
+      # regardless of the env var — note SHARD_COUNT-era scripts don't count).
+      # On those branches only shard 1 runs — one full run, not 4 duplicates.
+      - name: Detect shard support
+        id: shard-support
+        shell: bash
+        run: echo "run=$( { grep -qsF '"$SHARD"' ui/scripts/run-storybook-tests.sh || [ "${{ matrix.shard }}" = "1" ]; } && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
       - name: Setup - Frontend
+        if: steps.shard-support.outputs.run == 'true'
         uses: kestra-io/actions/composite/setup-frontend@main
 
       - name: Setup - OpenTelemetry
         uses: kestra-io/actions/actions/otel-collect@main
-        if: ${{ env.OTLP_ENDPOINT != '' }}
+        if: ${{ env.OTLP_ENDPOINT != '' && steps.shard-support.outputs.run == 'true' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
@@ -142,6 +152,7 @@ jobs:
       # set must not share it, or a first-writer cache poisons this one.
       - name: Cache Playwright Binaries
         id: cache-playwright
+        if: steps.shard-support.outputs.run == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -150,17 +161,18 @@ jobs:
 
       - name: Storybook - Install Playwright
         working-directory: ui
-        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        if: steps.shard-support.outputs.run == 'true' && steps.cache-playwright.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Run storybook component tests
+        if: steps.shard-support.outputs.run == 'true'
         working-directory: ui
         env:
           SHARD: ${{ matrix.shard }}/4
         run: npm run test:storybook
 
       - name: Upload JUnit report
-        if: always()
+        if: always() && steps.shard-support.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ui-test-report-storybook-${{ matrix.shard }}

--- a/.github/workflows/kestra-oss-frontend-tests.yml
+++ b/.github/workflows/kestra-oss-frontend-tests.yml
@@ -15,18 +15,20 @@ env:
   COREPACK_INTEGRITY_KEYS: 0
   OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
 
+# The former single sequential job is split into three independent jobs so the
+# wall time is max(checks, unit, storybook) instead of their sum; a final
+# report job aggregates both JUnit reports into the single PR comment.
 jobs:
-  test:
-    name: Frontend - Tests
+  checks:
+    name: Frontend - Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22.18.0'
+      - name: Setup - Frontend
+        uses: kestra-io/actions/composite/setup-frontend@main
 
       - name: Setup - OpenTelemetry
         uses: kestra-io/actions/actions/otel-collect@main
@@ -38,27 +40,18 @@ jobs:
           host-metrics-enabled: 'true'
           service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"
 
-      - name: Cache Node Modules
-        id: cache-node-modules
+      # vue-tsc revalidates restored .tsbuildinfo by content hash, so a stale
+      # restore only costs a re-check; restore-keys make warm PRs incremental.
+      - name: Cache vue-tsc incremental state
         uses: actions/cache@v4
         with:
           path: |
-            ui/node_modules
-          key: modules-${{ hashFiles('ui/package-lock.json') }}
+            ui/node_modules/.tmp
+            ui/packages/design-system/node_modules/.tmp
+          key: tsbuildinfo-${{ hashFiles('ui/package-lock.json') }}-${{ github.sha }}
+          restore-keys: |
+            tsbuildinfo-${{ hashFiles('ui/package-lock.json') }}-
 
-      - name: Cache Playwright Binaries
-        id: cache-playwright
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: playwright-${{ hashFiles('ui/package-lock.json') }}
-
-      - name: Npm - install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        working-directory: ui
-        run: npm ci
-    
       - name: Npm - check types
         working-directory: ui
         run: npm run check:types
@@ -76,29 +69,127 @@ jobs:
           reporter: github-pr-review
           workdir: ui
 
+      # Production build; only feeds the Codecov bundle-analysis plugin.
       - name: Npm - Run build
         working-directory: ui
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: npm run build
 
+  unit:
+    name: Frontend - Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup - Frontend
+        uses: kestra-io/actions/composite/setup-frontend@main
+
+      - name: Setup - OpenTelemetry
+        uses: kestra-io/actions/actions/otel-collect@main
+        if: ${{ env.OTLP_ENDPOINT != '' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
+          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
+          host-metrics-enabled: 'true'
+          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"
+
       - name: Run front-end unit tests
         working-directory: ui
-        run: npm run test:unit -- --coverage
+        run: npm run test:unit
+
+      - name: Upload JUnit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-report-unit
+          path: ui/test-report.junit.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Sharded because a browser session degrades as story files accumulate
+  # (Monaco worker memory) — each shard gets a fresh process and browser.
+  # Running the shards as a matrix makes them parallel instead of sequential.
+  storybook:
+    name: Frontend - Storybook Tests (${{ matrix.shard }}/4)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup - Frontend
+        uses: kestra-io/actions/composite/setup-frontend@main
+
+      - name: Setup - OpenTelemetry
+        uses: kestra-io/actions/actions/otel-collect@main
+        if: ${{ env.OTLP_ENDPOINT != '' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          otlp-endpoint: ${{ secrets.OTLP_ENDPOINT }}
+          otlp-headers: "${{ secrets.OTLP_HEADERS }}"
+          host-metrics-enabled: 'true'
+          service-name: "Github Actions - ${{ github.repository }} - ${{ github.workflow }}"
+
+      # Key is browser-set-specific: other jobs installing a different browser
+      # set must not share it, or a first-writer cache poisons this one.
+      - name: Cache Playwright Binaries
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('ui/package-lock.json') }}
 
       - name: Storybook - Install Playwright
         working-directory: ui
         if: steps.cache-playwright.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
 
       - name: Run storybook component tests
         working-directory: ui
-        run: npm run test:storybook -- --coverage
+        env:
+          SHARD: ${{ matrix.shard }}/4
+        run: npm run test:storybook
 
-      # Runs on success too (not just failure): that's what lets it clear a
-      # stale failures comment once the suite goes back to green.
-      - name: Report failing UI tests on the PR
+      - name: Upload JUnit report
         if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-report-storybook-${{ matrix.shard }}
+          path: ui/test-report.storybook-*.junit.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Runs on success too (not just failure): that's what lets it clear a
+  # stale failures comment once the suite goes back to green.
+  report:
+    name: Frontend - Report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [unit, storybook]
+    if: always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # Zero matches is fine (a job may have died before writing its report);
+      # the reporter treats a missing file as zero failures.
+      - name: Download JUnit reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ui-test-report-*
+          merge-multiple: true
+          path: ui
+
+      - name: Report failing UI tests on the PR
         uses: kestra-io/actions/composite/report-ui-test-failures@main
         with:
           github-token: ${{ secrets.GITHUB_AUTH_TOKEN }}

--- a/.github/workflows/kestra-oss-pullrequest-publish-docker.yml
+++ b/.github/workflows/kestra-oss-pullrequest-publish-docker.yml
@@ -8,6 +8,14 @@ on:
         type: string
         default: '21'
         required: false
+      skip-build:
+        description: >-
+          Skip the nested artifact build and reuse the `exe` artifact already
+          uploaded by another job of this workflow run (e.g. a hoisted Build
+          Artifacts job shared with the E2E tests).
+        type: boolean
+        default: false
+        required: false
 
 env:
   OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
@@ -15,14 +23,16 @@ env:
 jobs:
   build-artifacts:
     name: Build Artifacts
-    if: github.event.pull_request.head.repo.full_name == github.repository # prevent running on forks
+    if: ${{ !inputs.skip-build && github.event.pull_request.head.repo.full_name == github.repository }} # prevent running on forks
     uses: ./.github/workflows/kestra-oss-build-artifacts.yml
     with:
       java-version: ${{ inputs.java-version }}
-      
+
   publish:
     name: Publish Docker
-    if: github.event.pull_request.head.repo.full_name == github.repository # prevent running on forks
+    # `!cancelled()` lets this run when build-artifacts was skipped (skip-build:
+    # the `exe` artifact then comes from another job of the same run).
+    if: ${{ !cancelled() && needs.build-artifacts.result != 'failure' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     needs: build-artifacts
     env:

--- a/composite/report-ui-test-failures/action.yml
+++ b/composite/report-ui-test-failures/action.yml
@@ -38,9 +38,12 @@ inputs:
     required: false
     default: "ui/test-report.junit.xml"
   storybook-report-path:
-    description: "Repo-relative path to the Storybook tests JUnit XML report."
+    description: >-
+      Repo-relative path to the Storybook tests JUnit XML report. May contain
+      a `*` to match one report per CI shard; the old single-file name still
+      matches, so branches producing either layout are covered.
     required: false
-    default: "ui/test-report.storybook.junit.xml"
+    default: "ui/test-report.storybook*.junit.xml"
   max-listed-failures:
     description: "Maximum number of failing tests to list individually before trimming to a count + run link."
     required: false

--- a/composite/report-ui-test-failures/report-failures.js
+++ b/composite/report-ui-test-failures/report-failures.js
@@ -1,6 +1,19 @@
 const fs = require("fs")
+const path = require("path")
 
 const COMMENT_MARKER = "<!-- kestra:ui-test-failures-report -->"
+
+// Report paths may contain a `*` (e.g. one JUnit file per CI shard); expand it
+// against the containing directory. A plain path passes through unchanged.
+function expandReportPath(reportPath) {
+    if (!reportPath.includes("*")) return [reportPath]
+
+    const dir = path.dirname(reportPath)
+    if (!fs.existsSync(dir)) return []
+
+    const pattern = new RegExp(`^${path.basename(reportPath).split("*").map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join(".*")}$`)
+    return fs.readdirSync(dir).filter((name) => pattern.test(name)).sort().map((name) => path.join(dir, name))
+}
 
 function decodeXmlEntities(value) {
     return value
@@ -155,8 +168,10 @@ async function run({github, context, core, basePath, repoPath, reports, maxListe
     // older ones won't have a given project's JUnit reporter configured —
     // or the project itself — so its report file will never exist there.
     const failures = reports.flatMap(({path: reportPath, category}) => {
-        if (!reportPath || !fs.existsSync(reportPath)) return []
-        return parseJUnitFailures(fs.readFileSync(reportPath, "utf8"), category)
+        if (!reportPath) return []
+        return expandReportPath(reportPath)
+            .filter((expanded) => fs.existsSync(expanded))
+            .flatMap((expanded) => parseJUnitFailures(fs.readFileSync(expanded, "utf8"), category))
     })
 
     const repository = `${context.repo.owner}/${context.repo.repo}`

--- a/composite/setup-frontend/action.yml
+++ b/composite/setup-frontend/action.yml
@@ -1,0 +1,41 @@
+name: "Setup frontend"
+description: >-
+  Node + npm dependency setup for the Kestra OSS UI (`ui/`), shared by the
+  frontend test jobs. Restores the node_modules cache (including workspace
+  package trees) and runs `npm ci` only on a cache miss, with the npm download
+  cache as a second-level fallback so misses stay cheap.
+
+inputs:
+  node-version:
+    description: "Node version to install."
+    required: false
+    default: '22.18.0'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'npm'
+        cache-dependency-path: 'ui/package-lock.json'
+
+    # `.tmp` (vue-tsc incremental state) is deliberately excluded: it is cached
+    # separately with a per-commit key so it doesn't get pinned by the lockfile key.
+    - name: Cache Node Modules
+      id: cache-node-modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          ui/node_modules
+          ui/packages/*/node_modules
+          !ui/node_modules/.tmp
+          !ui/packages/*/node_modules/.tmp
+        key: modules-v2-${{ hashFiles('ui/package-lock.json', 'ui/patches/**') }}
+
+    - name: Npm - install
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      working-directory: ui
+      shell: bash
+      run: npm ci


### PR DESCRIPTION
Companion PR (merge this one **first**): kestra-io/kestra#17737

## What

Cuts the OSS frontend CI critical path from a measured **10m20s–11m30s** to an expected **~2.5–3.5 min**:

- **`kestra-oss-frontend-tests.yml` split into parallel jobs**: `checks` (types/lint/build, with a vue-tsc tsbuildinfo cache), `unit`, `storybook` as a **4-shard matrix** (previously 4 sequential shards inside one job), and a `report` job aggregating the JUnit artifacts into the existing PR comment. `report-ui-test-failures` now expands a `*` glob so per-shard reports work; the old single-file name still matches.
- **`composite/setup-frontend`**: shared Node + node_modules cache + `npm ci`. The cache now includes `ui/packages/*/node_modules` (previously missing on cache hits) and is keyed on `ui/patches/**`.
- **Cache fixes**: the three frontend-ish workflows shared one Playwright cache key while installing *different* browser sets (first writer poisoned the rest) — all now install chromium only under a browser-set-specific key. 30-min timeouts added (was the 6h default). `--coverage` dropped: the reports were never uploaded anywhere.
- **Build once per PR**: `kestra-oss-e2e-tests.yml` gains an `exe-artifact` input to build the Docker image under test from the Build Artifacts executable instead of rebuilding the whole product from source (empty input — forks, scheduled runs — keeps the source build); `kestra-oss-pullrequest-publish-docker.yml` gains `skip-build` so the caller hoists a single Build Artifacts job shared with E2E.

Also fixes a silent regression: Vitest ignores project-level `reporters`, so the JUnit files the PR comment reads were never produced. The companion PR moves them to CLI flags.

## Release-branch compatibility

Pinned `@main`, this workflow also serves `releases/*`. Verified against `v1.3.x` locally (storybook/unit/types green under the new step shapes) and guarded the storybook matrix: branches whose script predates `SHARD` support run only shard 1 — the same single full run they get today. Details in [this comment](https://github.com/kestra-io/actions/pull/169#issuecomment-5132396443).

## Merge order

⚠️ Merge before kestra-io/kestra#17737 — it passes the new inputs and uses `composite/setup-frontend`, which only exist here. Its CI fails with "invalid input" errors until this lands, then validates the whole setup live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)