### PR TITLE
ci(tests): upload frontend test coverage to Codecov

### DIFF
--- a/.github/workflows/kestra-ee-frontend-tests.yml
+++ b/.github/workflows/kestra-ee-frontend-tests.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Run front-end unit tests
         shell: bash
         working-directory: kestra-ee/ui-ee
-        run: npm run test:unit -- --coverage
+        run: npm run test:unit
 
       - name: Storybook - Install Playwright
         if: steps.cache-playwright.outputs.cache-hit != 'true'
@@ -107,7 +107,7 @@ jobs:
       - name: Run Storybook component tests
         shell: bash
         working-directory: kestra-ee/ui-ee
-        run: npm run test:storybook -- --coverage
+        run: npm run test:storybook
 
       # Runs on success too (not just failure): that's what lets it clear a
       # stale failures comment once the suite goes back to green.

--- a/.github/workflows/kestra-ee-frontend-tests.yml
+++ b/.github/workflows/kestra-ee-frontend-tests.yml
@@ -96,7 +96,17 @@ jobs:
       - name: Run front-end unit tests
         shell: bash
         working-directory: kestra-ee/ui-ee
-        run: npm run test:unit
+        run: npm run test:unit -- --coverage --coverage.reportsDirectory=coverage/unit
+
+      - name: Codecov - Upload unit coverage
+        uses: codecov/codecov-action@v6
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ui-ee-unit
+          working-directory: kestra-ee
+          directory: ui-ee/coverage/unit
 
       - name: Storybook - Install Playwright
         if: steps.cache-playwright.outputs.cache-hit != 'true'
@@ -107,7 +117,17 @@ jobs:
       - name: Run Storybook component tests
         shell: bash
         working-directory: kestra-ee/ui-ee
-        run: npm run test:storybook
+        run: npm run test:storybook -- --coverage --coverage.reportsDirectory=coverage/storybook
+
+      - name: Codecov - Upload storybook coverage
+        uses: codecov/codecov-action@v6
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ui-ee-storybook
+          working-directory: kestra-ee
+          directory: ui-ee/coverage/storybook
 
       # Runs on success too (not just failure): that's what lets it clear a
       # stale failures comment once the suite goes back to green.

--- a/.github/workflows/kestra-oss-designsystem-tests.yml
+++ b/.github/workflows/kestra-oss-designsystem-tests.yml
@@ -6,6 +6,9 @@ on:
       GITHUB_AUTH_TOKEN:
         description: "The GitHub Token."
         required: true
+      CODECOV_TOKEN:
+        description: 'Codecov Token'
+        required: false
 
 env:
   # to save corepack from itself
@@ -62,7 +65,16 @@ jobs:
 
       - name: Run front-end unit tests
         working-directory: ui/packages/design-system
-        run: npm run unit:test
+        run: npm run unit:test -- --coverage --coverage.reportsDirectory=coverage/unit
+
+      - name: Codecov - Upload unit coverage
+        uses: codecov/codecov-action@v6
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: design-system-unit
+          directory: ui/packages/design-system/coverage/unit
 
       - name: Storybook - Install Playwright
         working-directory: ui/packages/design-system
@@ -71,4 +83,13 @@ jobs:
 
       - name: Run storybook component tests
         working-directory: ui/packages/design-system
-        run: npm run storybook:test
+        run: npm run storybook:test -- --coverage --coverage.reportsDirectory=coverage/storybook
+
+      - name: Codecov - Upload storybook coverage
+        uses: codecov/codecov-action@v6
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: design-system-storybook
+          directory: ui/packages/design-system/coverage/storybook

--- a/.github/workflows/kestra-oss-designsystem-tests.yml
+++ b/.github/workflows/kestra-oss-designsystem-tests.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run front-end unit tests
         working-directory: ui/packages/design-system
-        run: npm run unit:test -- --coverage
+        run: npm run unit:test
 
       - name: Storybook - Install Playwright
         working-directory: ui/packages/design-system
@@ -71,4 +71,4 @@ jobs:
 
       - name: Run storybook component tests
         working-directory: ui/packages/design-system
-        run: npm run storybook:test -- --coverage
+        run: npm run storybook:test

--- a/.github/workflows/kestra-oss-frontend-tests.yml
+++ b/.github/workflows/kestra-oss-frontend-tests.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Run front-end unit tests
         working-directory: ui
-        run: npm run test:unit -- --coverage
+        run: npm run test:unit
 
       - name: Storybook - Install Playwright
         working-directory: ui
@@ -93,7 +93,7 @@ jobs:
 
       - name: Run storybook component tests
         working-directory: ui
-        run: npm run test:storybook -- --coverage
+        run: npm run test:storybook
 
       # Runs on success too (not just failure): that's what lets it clear a
       # stale failures comment once the suite goes back to green.

--- a/.github/workflows/kestra-oss-frontend-tests.yml
+++ b/.github/workflows/kestra-oss-frontend-tests.yml
@@ -84,7 +84,16 @@ jobs:
 
       - name: Run front-end unit tests
         working-directory: ui
-        run: npm run test:unit
+        run: npm run test:unit -- --coverage --coverage.reportsDirectory=coverage/unit
+
+      - name: Codecov - Upload unit coverage
+        uses: codecov/codecov-action@v6
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ui-unit
+          directory: ui/coverage/unit
 
       - name: Storybook - Install Playwright
         working-directory: ui
@@ -93,7 +102,16 @@ jobs:
 
       - name: Run storybook component tests
         working-directory: ui
-        run: npm run test:storybook
+        run: npm run test:storybook -- --coverage --coverage.reportsDirectory=coverage/storybook
+
+      - name: Codecov - Upload storybook coverage
+        uses: codecov/codecov-action@v6
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ui-storybook
+          directory: ui/coverage/storybook
 
       # Runs on success too (not just failure): that's what lets it clear a
       # stale failures comment once the suite goes back to green.


### PR DESCRIPTION
## Summary
- Re-enable `--coverage` on the frontend unit/Storybook Vitest steps (OSS `ui`, OSS `design-system`, EE `ui-ee`), each writing to its own `reportsDirectory` so the two suites don't overwrite each other's report.
- Upload each as a separate Codecov flag (`ui-unit`, `ui-storybook`, `design-system-unit`, `design-system-storybook`, `ui-ee-unit`, `ui-ee-storybook`).
- `kestra-oss-designsystem-tests.yml` now accepts an optional `CODECOV_TOKEN` secret for its new upload steps.
- Companion changes (Codecov policy config, vitest reporter tweaks, caller-workflow token wiring) are in kestra-io/kestra#17749 and kestra-io/kestra-ee#9610.

⚠️ Overlaps with #169 (same frontend workflow files, also touches `--coverage`) — please coordinate merge order.

## Test plan
- [x] Confirmed a clean, isolated `vitest run --coverage --coverage.reportsDirectory=...` produces a valid `lcov.info`/`clover.xml` with real `src/` paths.
- [ ] CI run on the consuming PRs (kestra-io/kestra#17749, kestra-io/kestra-ee#9610) exercises these workflow changes and the Codecov upload steps succeed.
