### PR TITLE
fix(ci): skip PR Docker build/publish for Dependabot PRs

### DIFF
--- a/.github/workflows/kestra-oss-pullrequest-publish-docker.yml
+++ b/.github/workflows/kestra-oss-pullrequest-publish-docker.yml
@@ -15,14 +15,16 @@ env:
 jobs:
   build-artifacts:
     name: Build Artifacts
-    if: github.event.pull_request.head.repo.full_name == github.repository # prevent running on forks
+    # prevent running on forks; Dependabot PRs aren't forks but GitHub still denies
+    # them a write-capable GITHUB_TOKEN, so publish would fail on ghcr.io push anyway
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/kestra-oss-build-artifacts.yml
     with:
       java-version: ${{ inputs.java-version }}
-      
+
   publish:
     name: Publish Docker
-    if: github.event.pull_request.head.repo.full_name == github.repository # prevent running on forks
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     needs: build-artifacts
     env:


### PR DESCRIPTION
Dependabot PRs aren't forks, so `build-artifacts`/`publish` ran anyway — but GitHub issues a read-only `GITHUB_TOKEN` for workflow runs it triggers, so the `ghcr.io` push always failed with `denied: installation not allowed to Write organization package`. Skips both jobs for `github.actor == 'dependabot[bot]'`.

Companion fix in `kestra-io/kestra` (same branch name) skips the `trigger-ee` job's secret-dependent steps for the same reason.

Fixes e.g. https://github.com/kestra-io/kestra/actions/runs/30426932220/job/90495855784

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAuvvjYvzZen9LgnLoNY42)_