### PR TITLE
chore(tests): remove frontend test coverage collection from CI

### DIFF
--- a/.github/workflows/kestra-ee-frontend-tests.yml
+++ b/.github/workflows/kestra-ee-frontend-tests.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Run front-end unit tests
         shell: bash
         working-directory: kestra-ee/ui-ee
-        run: npm run test:unit -- --coverage
+        run: npm run test:unit
 
       - name: Storybook - Install Playwright
         if: steps.cache-playwright.outputs.cache-hit != 'true'
@@ -107,7 +107,7 @@ jobs:
       - name: Run Storybook component tests
         shell: bash
         working-directory: kestra-ee/ui-ee
-        run: npm run test:storybook -- --coverage
+        run: npm run test:storybook
 
       # Runs on success too (not just failure): that's what lets it clear a
       # stale failures comment once the suite goes back to green.

--- a/.github/workflows/kestra-oss-designsystem-tests.yml
+++ b/.github/workflows/kestra-oss-designsystem-tests.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run front-end unit tests
         working-directory: ui/packages/design-system
-        run: npm run unit:test -- --coverage
+        run: npm run unit:test
 
       - name: Storybook - Install Playwright
         working-directory: ui/packages/design-system
@@ -71,4 +71,4 @@ jobs:
 
       - name: Run storybook component tests
         working-directory: ui/packages/design-system
-        run: npm run storybook:test -- --coverage
+        run: npm run storybook:test

--- a/.github/workflows/kestra-oss-frontend-tests.yml
+++ b/.github/workflows/kestra-oss-frontend-tests.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Run front-end unit tests
         working-directory: ui
-        run: npm run test:unit -- --coverage
+        run: npm run test:unit
 
       - name: Storybook - Install Playwright
         working-directory: ui
@@ -93,7 +93,7 @@ jobs:
 
       - name: Run storybook component tests
         working-directory: ui
-        run: npm run test:storybook -- --coverage
+        run: npm run test:storybook
 
       # Runs on success too (not just failure): that's what lets it clear a
       # stale failures comment once the suite goes back to green.


### PR DESCRIPTION
## Summary
- Drop the `-- --coverage` flag from the Vitest unit/Storybook test invocations in the reusable OSS frontend, EE frontend, and OSS design-system test workflows.
- `codecov.yml` in both `kestra-io/kestra` and `kestra-io/kestra-ee` already excludes `ui/**` from coverage reporting, so these coverage reports were generated on every CI run and never consumed anywhere — pure wasted CI time (coverage instrumentation slows down Vitest runs).
- No behavior change to test results/reporting; only the coverage instrumentation is removed.

## Test plan
- [x] Diff reviewed: only removes `-- --coverage` from 6 `npm run` invocations across 3 workflow files, no other changes.
- [ ] CI on this PR (and on the downstream OSS/EE PRs that consume `@main` of these workflows) runs frontend/design-system tests successfully without coverage flags.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MvRgsLQ6sHPbwwwWEYQoRq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvRgsLQ6sHPbwwwWEYQoRq)_