### PR TITLE
feat(workflows): build once per PR, skip E2E/Docker rebuilds when unneeded

### DIFF
--- a/.github/workflows/kestra-ee-e2e-tests.yml
+++ b/.github/workflows/kestra-ee-e2e-tests.yml
@@ -22,6 +22,15 @@ on:
         type: string
         default: '21'
         required: false
+      exe-artifact:
+        description: >-
+          Name of a Kestra executable artifact already uploaded by this workflow
+          run (e.g. `exe` from Build Artifacts). When set, the Docker image under
+          test is built from it instead of rebuilding the product from source;
+          leave empty (forks, scheduled runs) to build from source.
+        type: string
+        default: ''
+        required: false
 
 env:
   OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
@@ -49,14 +58,17 @@ jobs:
       - name: Checkout - OSS
         uses: kestra-io/actions/composite/kestra-ee/kestra-ee-checkout@main
 
+      # Java only exists to build the product from source, so it's skipped
+      # when a prebuilt executable artifact is provided.
       - name: setup init
         uses: kestra-io/actions/composite/setup-build@main
         with:
-          java-enabled: 'true'
+          java-enabled: ${{ inputs.exe-artifact == '' && 'true' || 'false' }}
           node-enabled: 'true'
           java-version: ${{ inputs.java-version }}
 
       - name: Setup - Maven proxy
+        if: ${{ inputs.exe-artifact == '' }}
         uses: kestra-io/actions/composite/kestra-ee/setup-maven-proxy@main
         with:
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -117,12 +129,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y make
 
+      - name: Artifacts - Download executable
+        if: ${{ inputs.exe-artifact != '' }}
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ inputs.exe-artifact }}
+          path: kestra-ee/build/executable
+
       - name: Run EE E2E Tests
         working-directory: kestra-ee
         shell: bash
         env:
           APPLICATION_SECRETS: ${{ secrets.APPLICATION_SECRETS }}
           NODE_OPTIONS: "--max-old-space-size=4096"
+          E2E_USE_PREBUILT_EXE: ${{ inputs.exe-artifact != '' }}
         run: |
           echo $APPLICATION_SECRETS | base64 -d > ./ui-ee/tests/e2e/data/application-secrets.yml
           echo $GOOGLE_SERVICE_ACCOUNT | base64 -d > $(pwd)/.gcp-service-account.json

--- a/.github/workflows/kestra-ee-pullrequest-publish-docker.yml
+++ b/.github/workflows/kestra-ee-pullrequest-publish-docker.yml
@@ -17,6 +17,14 @@ on:
         type: string
         default: '21'
         required: false
+      skip-build:
+        description: >-
+          Skip the nested artifact build and reuse the `exe` artifact already
+          uploaded by another job of this workflow run (e.g. a hoisted Build
+          Artifacts job shared with the E2E tests).
+        type: boolean
+        default: false
+        required: false
 
 env:
   OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
@@ -27,6 +35,7 @@ jobs:
   # ********************************************************************************************************************
   build-artifacts:
     name: Build Artifacts
+    if: ${{ !inputs.skip-build }}
     uses: ./.github/workflows/kestra-ee-build-artifacts.yml
     secrets:
       GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
@@ -44,6 +53,9 @@ jobs:
     name: Publish docker
     runs-on: kestra-private-standard
     needs: build-artifacts
+    # `!cancelled()` lets this run when build-artifacts was skipped (skip-build:
+    # the `exe` artifact then comes from another job of the same run).
+    if: ${{ !cancelled() && needs.build-artifacts.result != 'failure' }}
     env:
       GITHUB_IMAGE_PATH: ghcr.io/kestra-io/kestra-ee-pr
     steps:

--- a/.github/workflows/kestra-oss-e2e-tests.yml
+++ b/.github/workflows/kestra-oss-e2e-tests.yml
@@ -13,6 +13,15 @@ on:
         type: string
         default: '21'
         required: false
+      exe-artifact:
+        description: >-
+          Name of a Kestra executable artifact already uploaded by this workflow
+          run (e.g. `exe` from Build Artifacts). When set, the Docker image under
+          test is built from it instead of rebuilding the product from source;
+          leave empty (forks, scheduled runs) to build from source.
+        type: string
+        default: ''
+        required: false
 
 env:
   OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
@@ -34,14 +43,15 @@ jobs:
         with:
           path: kestra
 
-      # Setup build
+      # Setup build. Java/python only exist to build the product from source,
+      # so both are skipped when a prebuilt executable artifact is provided.
       - uses: kestra-io/actions/composite/setup-build@main
         name: Setup - Build
         id: build
         with:
-          java-enabled: true
+          java-enabled: ${{ inputs.exe-artifact == '' && 'true' || 'false' }}
           node-enabled: true
-          python-enabled: true
+          python-enabled: ${{ inputs.exe-artifact == '' && 'true' || 'false' }}
           java-version: ${{ inputs.java-version }}
 
       - name: Setup - OpenTelemetry
@@ -69,7 +79,16 @@ jobs:
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         run: cd kestra/ui && npx playwright install --with-deps chromium
 
+      - name: Artifacts - Download executable
+        if: ${{ inputs.exe-artifact != '' }}
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ inputs.exe-artifact }}
+          path: kestra/build/executable
+
       - name: Run E2E Tests
+        env:
+          E2E_USE_PREBUILT_EXE: ${{ inputs.exe-artifact != '' }}
         run: |
           cd kestra
           sh build-and-start-e2e-tests.sh

--- a/.github/workflows/kestra-oss-pullrequest-publish-docker.yml
+++ b/.github/workflows/kestra-oss-pullrequest-publish-docker.yml
@@ -8,6 +8,14 @@ on:
         type: string
         default: '21'
         required: false
+      skip-build:
+        description: >-
+          Skip the nested artifact build and reuse the `exe` artifact already
+          uploaded by another job of this workflow run (e.g. a hoisted Build
+          Artifacts job shared with the E2E tests).
+        type: boolean
+        default: false
+        required: false
 
 env:
   OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
@@ -15,14 +23,16 @@ env:
 jobs:
   build-artifacts:
     name: Build Artifacts
-    if: github.event.pull_request.head.repo.full_name == github.repository # prevent running on forks
+    if: ${{ !inputs.skip-build && github.event.pull_request.head.repo.full_name == github.repository }} # prevent running on forks
     uses: ./.github/workflows/kestra-oss-build-artifacts.yml
     with:
       java-version: ${{ inputs.java-version }}
-      
+
   publish:
     name: Publish Docker
-    if: github.event.pull_request.head.repo.full_name == github.repository # prevent running on forks
+    # `!cancelled()` lets this run when build-artifacts was skipped (skip-build:
+    # the `exe` artifact then comes from another job of the same run).
+    if: ${{ !cancelled() && needs.build-artifacts.result != 'failure' && github.event.pull_request.head.repo.full_name == github.repository }} # prevent running on forks
     runs-on: ubuntu-latest
     needs: build-artifacts
     env:


### PR DESCRIPTION
## What

Companion infra change extracted from the "Build once per PR, skip what's unneeded" idea in kestra-io/kestra#17737, split out on its own so it can land independently of that PR's storybook/vitest performance work.

Both the OSS and EE pull-request pipelines currently run a `Build Artifacts` job to publish the PR Docker image, and separately rebuild the *entire* product from source again inside the E2E tests job — same `npm run build` + Gradle `executableJar`, done twice, in parallel, on every PR.

This PR adds the plumbing so a caller can hoist a single `Build Artifacts` job and share its executable between both jobs instead:

- **`kestra-oss-e2e-tests.yml`** / **`kestra-ee-e2e-tests.yml`**: new `exe-artifact` input. When set to the name of an executable artifact already uploaded earlier in the same workflow run, the Java/Maven-proxy setup is skipped and the artifact is downloaded straight into `build/executable`, so only the Docker image needs building. Left empty (forks, scheduled runs, or when no shared build exists), the job builds from source exactly as before.
- **`kestra-oss-pullrequest-publish-docker.yml`** / **`kestra-ee-pullrequest-publish-docker.yml`**: new `skip-build` input. When `true`, the nested `Build Artifacts` job is skipped and the publish job reuses the `exe` artifact from another job of the same run (with `!cancelled() && needs.build-artifacts.result != 'failure'` so it still runs when the build was intentionally skipped).

Both inputs default to their current behavior (empty / `false`), so this is backwards compatible with every other caller of these reusable workflows.

## Merge order

⚠️ Merge this **before**:
- kestra-io/kestra#17750 (OSS companion PR)
- kestra-io/kestra-ee#9613 (EE companion PR)

Those PRs pass the new inputs, which don't exist on `main` until this lands — their CI will fail with "invalid input" errors until this merges, then a re-run validates the whole setup live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)