### PR TITLE
build(deps): upgrade Node to 24 LTS

### DIFF
--- a/.github/workflows/kestra-ee-frontend-tests.yml
+++ b/.github/workflows/kestra-ee-frontend-tests.yml
@@ -29,7 +29,7 @@ jobs:
         uses: kestra-io/actions/composite/setup-build@main
         with:
           node-enabled: true
-          node-version: '22.18.0'
+          node-version: '24.x'
 
       - name: Setup - OpenTelemetry
         uses: kestra-io/actions/actions/otel-collect@main

--- a/.github/workflows/kestra-oss-designsystem-tests.yml
+++ b/.github/workflows/kestra-oss-designsystem-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22.18.0'
+          node-version: '24.x'
 
       - name: Setup - OpenTelemetry
         uses: kestra-io/actions/actions/otel-collect@main

--- a/.github/workflows/kestra-oss-frontend-tests.yml
+++ b/.github/workflows/kestra-oss-frontend-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22.18.0'
+          node-version: '24.x'
 
       - name: Setup - OpenTelemetry
         uses: kestra-io/actions/actions/otel-collect@main

--- a/composite/kestra-ee/kestra-ee-generate-translations/action.yml
+++ b/composite/kestra-ee/kestra-ee-generate-translations/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Set up Node
       uses: actions/setup-node@v6
       with:
-        node-version: "20.x"
+        node-version: "24.x"
 
     - name: Install Node dependencies
       run: npm ci
@@ -53,7 +53,7 @@ runs:
     - name: Set up Node
       uses: actions/setup-node@v4
       with:
-        node-version: "20.x"
+        node-version: "24.x"
 
     - name: Check keys matching
       shell: bash

--- a/composite/setup-build/action.yml
+++ b/composite/setup-build/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: true
   node-version:
     description: "Node version"
-    default: '22'
+    default: '24'
     required: true
   python-enabled:
     description: "Specify whether to setup Python"


### PR DESCRIPTION
## Description

Companion change to the OSS and EE Node 24 LTS upgrades — same branch name in all three repos.

- `composite/setup-build` default `node-version` `'22'` → `'24'`. This is the one every consumer that doesn't pass `node-version` explicitly inherits, so it's the highest-leverage line in the diff
- The three frontend/design-system test workflows `'22.18.0'` → `'24.x'`
- `kestra-ee-generate-translations` was still on `20.x` → `24.x` (both `setup-node` steps)

Workflows track the floating `24.x` rather than a pinned patch, so routine Node releases no longer need a commit here.

## Not in this PR: the `using: node20` action runtimes

`otel-collect`, `comment-update` and `github-release-note-merge` still declare `using: node20`. That is a **separate follow-up worth doing soon**, not a deliberate long-term choice:

- Node 20 is deprecated on Actions runners and is removed in fall 2026
- Runners have defaulted to Node 24 since 16 June 2026, so these actions already *execute* on Node 24 — they just declare `node20` and emit deprecation warnings
- `otel-collect` and `comment-update` already declare `engines: {"node": ">=22.0.0"}`, which contradicts their own `using: node20`

`using: node24` is the correct target (there is no `node26` runtime). Held back from this PR only because it changes the declared runtime for every consumer of these actions org-wide, which deserves its own review — one caveat being that Node 24 is unsupported on macOS 13.4 and older runners.

## Related PRs

Companion PRs on the identically-named branch — these must land together, and **this PR should go first** since it carries the shared `setup-build` default the other two inherit:

- [kestra-io/kestra#17764](https://github.com/kestra-io/kestra/pull/17764) — build(deps): upgrade Node to 24 LTS and unblock lint-staged majors
- [kestra-io/kestra-ee#9629](https://github.com/kestra-io/kestra-ee/pull/9629) — build(deps): upgrade Node to 24 LTS and unblock lint-staged majors