### PR TITLE
fix(tests): build the EE SDK before running E2E tests

### DIFF
--- a/.github/workflows/kestra-ee-e2e-tests.yml
+++ b/.github/workflows/kestra-ee-e2e-tests.yml
@@ -117,6 +117,16 @@ jobs:
         working-directory: kestra-ee/ui-ee
         run: npm ci
 
+      # tests/e2e/fixtures/shared.ts imports @kestra-io/kestra-sdk, whose exports resolve to
+      # dist/index.js. That dist is gitignored and the package has no prepare/postinstall, so
+      # npm ci alone never produces it and Playwright dies at import time before any test runs.
+      # Deliberately not gated on the node_modules cache: dist lives in packages/kestra-sdk,
+      # outside the cached path, so a cache hit would skip the build and leave it missing.
+      - name: EE build SDK
+        shell: bash
+        working-directory: kestra-ee/ui-ee
+        run: npm run build:sdk
+
       - name: Install Playwright
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         shell: bash


### PR DESCRIPTION
## Problem

`EE E2E - Tests / check` fails before a single test runs:

```
Error: Cannot find module '.../ui-ee/node_modules/@kestra-io/kestra-sdk/dist/index.js'
  imported from .../ui-ee/tests/e2e/fixtures/shared.ts
```

Deterministic, not flaky:

1. `ui-ee/tests/e2e/fixtures/shared.ts` imports `@kestra-io/kestra-sdk`, whose `exports` resolve to `./dist/index.js`
2. `ui-ee/packages/kestra-sdk/dist` is gitignored — generated, not committed
3. The package declares `build: tsdown` but **no** `prepare`/`postinstall`, so `npm ci` will not build it
4. This workflow ran OSS `npm ci` → EE `npm ci` → `playwright install` → tests, with no build step in between

The workspace symlink is fine (`node_modules/@kestra-io/kestra-sdk` → `packages/kestra-sdk`); only the build output was missing.

## Fix

Run the existing `build:sdk` script (`hey-api-plugin`, then `kestra-sdk`) after `npm ci`.

**The step is deliberately not gated on `cache-ee-node-modules`.** The cache path is `kestra-ee/ui-ee/node_modules`, but `dist` lives in `kestra-ee/ui-ee/packages/kestra-sdk/dist` — outside it. Gating on the cache the way the neighbouring `npm ci` step does would mean a cache hit skips the build and `dist` is missing all over again.

## Verification

Locally on Node 24.18.1, in `kestra-ee/ui-ee`:

- after `npm ci` alone → `packages/kestra-sdk/dist/index.js` **absent**, reproducing the CI failure exactly
- after `npm run build:sdk` → `node_modules/@kestra-io/kestra-sdk/dist/index.js` present (50 KB), and the three specifiers the fixture actually imports (bare, `/users`, `/bindings`) all resolve, with a dynamic import succeeding

## Scope

EE only — the OSS E2E suite does not import the SDK (zero matches under `ui/tests/e2e`), which is why only EE was red.

Found while working on [kestra-io/kestra-ee#9629](https://github.com/kestra-io/kestra-ee/pull/9629); the failure predates that PR and is unrelated to it. I suspect it arrived with the E2E restructure in #173, but I could not confirm that — the failing `develop` runs I checked broke in `Backend tests`, so there was no clean before/after comparison. Worth a sanity check from whoever owns this workflow.

An alternative fix would be adding `"prepare": "tsdown"` to the SDK package so `npm ci` always builds it. That is arguably better for local dev, but it does not fix this job on its own, because a `node_modules` cache hit skips `npm ci` entirely. Happy to do both if you'd prefer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSTPvLhWs5WwfXjg12v68u)_