### PR TITLE
feat(workflows): let the kestra-ee frontend suite take an explicit OSS/EE ref pair

### DIFF
--- a/.github/workflows/kestra-ee-frontend-tests.yml
+++ b/.github/workflows/kestra-ee-frontend-tests.yml
@@ -2,6 +2,32 @@ name: Frontend tests
 
 on:
   workflow_call:
+    inputs:
+      ee-ref:
+        description: >-
+          kestra-ee ref to check out. Empty (the default) checks out the ref of the
+          calling workflow's own event.
+        type: string
+        required: false
+        default: ""
+      oss-ref:
+        description: >-
+          OSS ref to check out. Empty (the default) resolves it from the calling
+          workflow's context via the kestra-ee-checkout composite.
+        type: string
+        required: false
+        default: ""
+      pr-reporting:
+        description: >-
+          Report lint findings and UI-test failures onto a pull request of the
+          calling repository. Turn this off for runs that have no PR of their own —
+          e.g. a repository_dispatch driven by an OSS PR, where there is nothing in
+          kestra-ee to comment on. The whole suite still runs either way; only the
+          reporting channel changes, and lint failures then surface as a failed step
+          instead of as review comments.
+        type: boolean
+        required: false
+        default: true
     secrets:
       CODECOV_TOKEN:
         description: "The Codecov token."
@@ -21,9 +47,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: kestra-ee
+          # An empty ref is actions/checkout's default, i.e. the ref of the event
+          # that started the calling workflow.
+          ref: ${{ inputs.ee-ref }}
 
       - name: Checkout - OSS
         uses: kestra-io/actions/composite/kestra-ee/kestra-ee-checkout@main
+        with:
+          oss-ref: ${{ inputs.oss-ref }}
 
       - name: setup build
         uses: kestra-io/actions/composite/setup-build@main
@@ -87,11 +118,20 @@ jobs:
         run: npx oxlint@latest
 
       - name: Npm - Lint (eslint)
+        if: ${{ inputs.pr-reporting }}
         uses: reviewdog/action-eslint@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           workdir: "kestra-ee/ui-ee"
+
+      # Same lint, minus the review-comment reporter, for runs with no PR of their
+      # own. reviewdog's github-pr-review reporter needs a pull_request event.
+      - name: Npm - Lint (eslint, no PR reporter)
+        if: ${{ !inputs.pr-reporting }}
+        shell: bash
+        working-directory: kestra-ee/ui-ee
+        run: npx eslint
 
       - name: Run front-end unit tests
         shell: bash
@@ -112,7 +152,7 @@ jobs:
       # Runs on success too (not just failure): that's what lets it clear a
       # stale failures comment once the suite goes back to green.
       - name: Report failing UI tests on the PR
-        if: always()
+        if: ${{ always() && inputs.pr-reporting }}
         uses: kestra-io/actions/composite/report-ui-test-failures@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/composite/kestra-ee/kestra-ee-checkout/action.yml
+++ b/composite/kestra-ee/kestra-ee-checkout/action.yml
@@ -1,6 +1,18 @@
 name: 'Kestra Action to Checkout'
 description: 'Composite action to checkout and prepare local file.'
 
+inputs:
+  oss-ref:
+    description: >-
+      Explicit OSS ref (branch, tag or SHA) to check out. Leave empty (the default)
+      to resolve it from the calling workflow's own context, which is what every
+      kestra-ee PR / push build wants. Set it when the caller already knows which
+      OSS tree to test — e.g. a repository_dispatch run driven by an OSS PR, where
+      github.head_ref and github.base_ref are both empty and the resolution below
+      would otherwise fall back to develop and silently test the wrong tree.
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -8,8 +20,19 @@ runs:
     - name: Checkout - Get checkout branch from OSS
       id: checkout-branch
       shell: bash
+      env:
+        OSS_REF: ${{ inputs.oss-ref }}
       run: |
-        
+
+        # An explicit ref wins over any context-based resolution. Read through the
+        # environment rather than interpolating it into the script, so a ref name
+        # can never be executed as shell.
+        if [[ -n "$OSS_REF" ]]; then
+          echo "explicit OSS ref requested: $OSS_REF"
+          echo "ossBranch=$OSS_REF" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         if ${{ github.event_name == 'pull_request' }}; then
       
             # try to find if there is an associated OSS branch


### PR DESCRIPTION
Enabler for [kestra-io/kestra#17805](https://github.com/kestra-io/kestra/issues/17805) — **merge this first**, since `kestra-ee` references these at `@main`.

## Why

`kestra-ee-frontend-tests.yml` checks out `kestra-ee` at the calling workflow's own ref, and lets `composite/kestra-ee/kestra-ee-checkout` derive the OSS ref from the `kestra-ee` pull-request context (`github.head_ref`, falling back to `github.base_ref`).

That is right for every `kestra-ee` PR and push build, but it cannot express *"test this specific OSS tree"*, so the suite cannot be driven from the OSS side. On a `repository_dispatch` run both `head_ref` and `base_ref` are empty, the resolution falls through to `develop`, and the suite would silently test the wrong OSS tree while reporting green.

## What

Three optional inputs, all defaulting to today's behaviour:

| Input | Default | Empty/false means |
|---|---|---|
| `ee-ref` | `""` | `actions/checkout`'s default, i.e. the ref of the calling workflow's event |
| `oss-ref` | `""` | keep the existing context-based resolution in `kestra-ee-checkout` |
| `pr-reporting` | `true` | keep reporting onto a PR of the calling repository |

`pr-reporting: false` is for runs that have no PR of their own to comment on. reviewdog's `github-pr-review` reporter requires a `pull_request` event, and the UI-test-failure comment needs an issue number, so both are swapped for a plain `npx eslint` step. **The whole suite still runs** — `check:types`, oxlint, eslint, unit and Storybook — only the reporting channel changes, and lint failures surface as a failed step instead of as review comments.

`kestra-ee-checkout` reads `oss-ref` through the environment rather than interpolating it into the shell script, so a ref name can never be executed as shell.

## Backward compatibility

No existing caller passes any of the new inputs, and every default reproduces current behaviour exactly, so this is a no-op for the three callers:

- `kestra-ee` `main-build.yml`
- `kestra-ee` `pull-request.yml`
- `kestra-ee` `pre-release.yml`

## Companion PRs

- `kestra-ee`: `ci/forward-oss-change-area-to-ee` — adds `oss-pr-frontend-check.yml`, which consumes these inputs
- `kestra`: `ci/forward-oss-change-area-to-ee` — dispatches it per change-area
