### PR TITLE
fix(report-java): skip failure-details comment on fork PRs

### DIFF
--- a/composite/report-java/action.yml
+++ b/composite/report-java/action.yml
@@ -45,7 +45,9 @@ runs:
           {% endif %}
 
     - name: Test - Comment PR with failure details
-      if: ${{ !cancelled() && github.event_name == 'pull_request' && startsWith(github.repository, 'kestra-io/') }}
+      # Skip on fork PRs: they get a read-only GITHUB_TOKEN, so the comment POST returns 403 and fails the job.
+      # Internal PRs still run this, so a genuine devtools failure still surfaces.
+      if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}


### PR DESCRIPTION
Fork PRs get a read-only GITHUB_TOKEN, so the devtools failure-details comment POST returns 403 and fails the job. Gate the step on `head.repo.fork == false`, matching kestra core's convention.