### PR TITLE
fix(otel-collect): declare OTLP secrets on reusable test workflows

### DIFF
--- a/.github/workflows/kestra-oss-backend-tests.yml
+++ b/.github/workflows/kestra-oss-backend-tests.yml
@@ -17,6 +17,12 @@ on:
         required: true
       DEVELOCITY_ACCESS_KEY:
         required: false
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
     inputs:
       java-version:
         description: "Java version"

--- a/.github/workflows/kestra-oss-designsystem-tests.yml
+++ b/.github/workflows/kestra-oss-designsystem-tests.yml
@@ -6,6 +6,12 @@ on:
       GITHUB_AUTH_TOKEN:
         description: "The GitHub Token."
         required: true
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
 
 env:
   # to save corepack from itself

--- a/.github/workflows/kestra-oss-frontend-tests.yml
+++ b/.github/workflows/kestra-oss-frontend-tests.yml
@@ -9,6 +9,12 @@ on:
       CODECOV_TOKEN:
         description: 'Codecov Token'
         required: true
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
 
 env:
   # to save corepack from itself


### PR DESCRIPTION
## Summary
- `kestra-oss-backend-tests.yml`, `kestra-oss-frontend-tests.yml`, and `kestra-oss-designsystem-tests.yml` reference `secrets.OTLP_ENDPOINT` / `secrets.OTLP_HEADERS` in their `env:` block, but never declared them under `on.workflow_call.secrets`.
- Callers that pass secrets explicitly (instead of `secrets: inherit`) can only forward secrets a reusable workflow declares — so `OTLP_ENDPOINT` resolved empty, the `if: env.OTLP_ENDPOINT != ''` guard on the `Setup - OpenTelemetry` step was always false, and the step (which starts the host-metrics `otelcol-contrib` collector) never ran.
- Found by tracing why `kestra-io/kestra` run [31623593288](https://github.com/kestra-io/kestra/actions/runs/31623593288) had a full trace (built post-hoc by the `export-all` job) but zero host metrics for its `backend-tests`/`frontend-tests`/`design-system-frontend-tests` jobs.
- Companion PR on `kestra-io/kestra`'s `main-build.yml` forwards these secrets at the call sites once this is merged.

## Test plan
- [ ] `yaml.safe_load` validated on all three changed files
- [ ] Merge this first, then merge the `kestra-io/kestra` companion PR
- [ ] After both land, confirm a subsequent `develop` run populates `metrics-hostmetricsreceiver.otel-github-actions` for `backend-tests`/`frontend-tests`/`design-system-frontend-tests`