### PR TITLE
fix(otel-collect): declare OTLP secrets on remaining reusable workflows

### DIFF
--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -15,6 +15,12 @@ on:
       CODECOV_TOKEN:
         description: "The Codecov token."
         required: false
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
     inputs:
       java-version:
         description: "Java version"

--- a/.github/workflows/kestra-ee-build-artifacts.yml
+++ b/.github/workflows/kestra-ee-build-artifacts.yml
@@ -12,6 +12,12 @@ on:
       CODECOV_TOKEN:
         description: 'Codecov Token'
         required: true
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
     inputs:
       java-version:
         description: "Java version"

--- a/.github/workflows/kestra-ee-e2e-tests.yml
+++ b/.github/workflows/kestra-ee-e2e-tests.yml
@@ -11,6 +11,12 @@ on:
       GCP_SERVICE_ACCOUNT:
         description: "GCP service account JSON for the Maven proxy (routes Gradle reads off Maven Central). Optional; when absent the proxy step is a no-op."
         required: false
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
     inputs:
       noInputYet:
         description: 'not input yet.'

--- a/.github/workflows/kestra-ee-frontend-tests.yml
+++ b/.github/workflows/kestra-ee-frontend-tests.yml
@@ -6,6 +6,12 @@ on:
       CODECOV_TOKEN:
         description: "The Codecov token."
         required: false
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
 
 env:
   OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}

--- a/.github/workflows/kestra-ee-publish-maven.yml
+++ b/.github/workflows/kestra-ee-publish-maven.yml
@@ -5,6 +5,12 @@ on:
     secrets:
       GCP_SERVICE_ACCOUNT:
         required: true
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
     inputs:
       java-version:
         description: "Java version"

--- a/.github/workflows/kestra-oss-backend-tests.yml
+++ b/.github/workflows/kestra-oss-backend-tests.yml
@@ -17,6 +17,12 @@ on:
         required: true
       DEVELOCITY_ACCESS_KEY:
         required: false
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
     inputs:
       java-version:
         description: "Java version"

--- a/.github/workflows/kestra-oss-build-artifacts.yml
+++ b/.github/workflows/kestra-oss-build-artifacts.yml
@@ -2,6 +2,13 @@ name: Build Artifacts
 
 on:
   workflow_call:
+    secrets:
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
     inputs:
       java-version:
         description: "Java version"

--- a/.github/workflows/kestra-oss-designsystem-tests.yml
+++ b/.github/workflows/kestra-oss-designsystem-tests.yml
@@ -6,6 +6,12 @@ on:
       GITHUB_AUTH_TOKEN:
         description: "The GitHub Token."
         required: true
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
 
 env:
   # to save corepack from itself

--- a/.github/workflows/kestra-oss-e2e-tests.yml
+++ b/.github/workflows/kestra-oss-e2e-tests.yml
@@ -2,6 +2,13 @@ name: 'E2E tests'
 # 'New E2E tests implementation started by Roman. Based on playwright in npm UI project, tests Kestra OSS develop docker image. These tests are written from zero, lets make them unflaky from the start!.'
 on:
   workflow_call:
+    secrets:
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
     inputs:
       noInputYet:
         description: 'not input yet.'

--- a/.github/workflows/kestra-oss-frontend-tests.yml
+++ b/.github/workflows/kestra-oss-frontend-tests.yml
@@ -9,6 +9,12 @@ on:
       CODECOV_TOKEN:
         description: 'Codecov Token'
         required: true
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
 
 env:
   # to save corepack from itself

--- a/.github/workflows/kestra-oss-publish-maven.yml
+++ b/.github/workflows/kestra-oss-publish-maven.yml
@@ -18,6 +18,12 @@ on:
       SONATYPE_GPG_FILE:
         description: "The Sonatype GPG file."
         required: true
+      OTLP_ENDPOINT:
+        description: 'OTLP endpoint for OpenTelemetry export'
+        required: false
+      OTLP_HEADERS:
+        description: 'OTLP headers for OpenTelemetry export'
+        required: false
     inputs:
       java-version:
         description: "Java version"


### PR DESCRIPTION
## Summary
Follow-up to #192, which fixed the 3 OSS test workflows. This covers the rest of the workflows in this repo that use `otel-collect` but never declared `OTLP_ENDPOINT`/`OTLP_HEADERS` under `on.workflow_call.secrets`:

- `kestra-oss-build-artifacts.yml`, `kestra-oss-e2e-tests.yml` — didn't declare *any* `workflow_call.secrets` at all, so callers had no way to pass OTLP secrets in short of `secrets: inherit`.
- `kestra-oss-publish-maven.yml` — declared Sonatype secrets only.
- `kestra-ee-backend-tests.yml`, `kestra-ee-frontend-tests.yml`, `kestra-ee-build-artifacts.yml`, `kestra-ee-e2e-tests.yml`, `kestra-ee-publish-maven.yml` — same gap on the EE side.

Checked every real caller in `kestra-io/kestra` and `kestra-io/kestra-ee`: none use `secrets: inherit` for these jobs, so this was silently disabling the `Setup - OpenTelemetry` step (and its host-metrics collector) across every PR check, pre-release, and scheduled e2e run that goes through build-artifacts, e2e-tests, or publish-maven — OSS and EE alike. (Plugin repos are unaffected — they call `plugins.yml` with `secrets: inherit`.)

Companion PRs on `kestra-io/kestra` and `kestra-io/kestra-ee` forward these secrets at each call site.

## Test plan
- [ ] `yaml.safe_load` validated on all 8 changed files
- [ ] Merge this before the `kestra`/`kestra-ee` companion PRs
- [ ] After all land, confirm host metrics show up for build-artifacts/e2e-tests/publish-maven jobs on both repos