### PR TITLE
ci: authenticate the kotlp download in the Java build jobs

### DIFF
--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -107,6 +107,11 @@ jobs:
       # timeout so a residual stall fails fast instead of burning the whole budget.
       - name: Gradle - javadoc
         timeout-minutes: 15
+        # Lets :script:downloadKotlp authenticate: GitHub throttles anonymous release-asset
+        # downloads by killing the connection, which this shared-egress-IP runner pool hits
+        # constantly, and authenticated reads get a far larger budget.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           echo $GOOGLE_SERVICE_ACCOUNT | base64 -d > $(pwd)/.gcp-service-account.json
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.gcp-service-account.json
@@ -116,6 +121,8 @@ jobs:
           ./gradlew javadoc --parallel
 
       - name: Gradle - check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           echo $GOOGLE_SERVICE_ACCOUNT | base64 -d > $(pwd)/.gcp-service-account.json
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.gcp-service-account.json

--- a/.github/workflows/kestra-ee-build-artifacts.yml
+++ b/.github/workflows/kestra-ee-build-artifacts.yml
@@ -102,6 +102,9 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           NODE_OPTIONS: "--max-old-space-size=4096"
+          # Lets :script:downloadKotlp authenticate against the GitHub release-asset throttle,
+          # which self-hosted runners behind a shared egress IP hit constantly.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           cd kestra-ee
           if [ "${{ steps.cloud-ee.outputs.exists }}" == "true" ]; then

--- a/.github/workflows/kestra-ee-publish-maven.yml
+++ b/.github/workflows/kestra-ee-publish-maven.yml
@@ -84,6 +84,8 @@ jobs:
         working-directory: kestra-ee
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
+          # Lets :script:downloadKotlp authenticate against the GitHub release-asset throttle.
+          GITHUB_TOKEN: ${{ github.token }}
         run: ./gradlew publish
 
       # Gradle dependency

--- a/.github/workflows/kestra-oss-backend-tests.yml
+++ b/.github/workflows/kestra-oss-backend-tests.yml
@@ -84,6 +84,10 @@ jobs:
       - name: Gradle - check and javadoc
         if: ${{ github.event.inputs.skip-test == 'false' || github.event.inputs.skip-test == '' }}
         shell: bash
+        # Lets :script:downloadKotlp authenticate: GitHub throttles anonymous release-asset
+        # downloads by killing the connection, and authenticated reads get a far larger budget.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           ./gradlew check javadoc --parallel
 

--- a/.github/workflows/kestra-oss-build-artifacts.yml
+++ b/.github/workflows/kestra-oss-build-artifacts.yml
@@ -65,6 +65,10 @@ jobs:
       # Build
       - name: Gradle - Build
         shell: bash
+        # Lets :script:downloadKotlp authenticate: GitHub throttles anonymous release-asset
+        # downloads by killing the connection, and authenticated reads get a far larger budget.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           ./gradlew executableJar
 

--- a/.github/workflows/kestra-oss-publish-maven.yml
+++ b/.github/workflows/kestra-oss-publish-maven.yml
@@ -80,6 +80,8 @@ jobs:
           SONATYPE_GPG_KEYID: ${{ secrets.SONATYPE_GPG_KEYID }}
           SONATYPE_GPG_PASSWORD: ${{ secrets.SONATYPE_GPG_PASSWORD }}
           SONATYPE_GPG_FILE: ${{ secrets.SONATYPE_GPG_FILE}}
+          # Lets :script:downloadKotlp authenticate against the GitHub release-asset throttle.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p ~/.gradle/
           echo "signing.keyId=${SONATYPE_GPG_KEYID}" > ~/.gradle/gradle.properties


### PR DESCRIPTION
## What

Exports `GITHUB_TOKEN: ${{ github.token }}` on the Gradle steps that build kestra / kestra-ee sources, so `:script:downloadKotlp` downloads its release asset authenticated:

| Workflow | Step |
|---|---|
| `kestra-oss-build-artifacts.yml` | Gradle - Build |
| `kestra-oss-backend-tests.yml` | Gradle - check and javadoc |
| `kestra-oss-publish-maven.yml` | Publish - Release package |
| `kestra-ee-build-artifacts.yml` | Gradle - Build jars |
| `kestra-ee-backend-tests.yml` | Gradle - javadoc, Gradle - check |
| `kestra-ee-publish-maven.yml` | Publish - Release package |

## Why

GitHub throttles **anonymous** release-asset downloads by closing the TCP connection without sending any HTTP response. Java's `HttpURLConnection` does not retry a fresh connection, so it surfaces as a hard build failure:

```
Execution failed for task ':script:downloadKotlp'
> Cannot download the kotlp binary from '.../releases/download/v0.1.0/kotlp': Unexpected end of file from server.
```

The throttle is per egress IP. The self-hosted `kestra-private-*` pool NATs every job out through one address, so EE hits it constantly while GitHub-hosted OSS runners (fresh IP per job) rarely do — the same commit could pass in OSS and fail in EE, or pass in one EE job and fail in another job of the same run ([example](https://github.com/kestra-io/kestra-ee/actions/runs/31617939821): `Backend - Tests / Check` downloaded fine while `Build Artifacts / Build Jar` failed 52s later). Measured locally, anonymous downloads failed ~15% of the time cold and above 40% after ~40 requests from one IP; authenticated downloads succeeded 6/6 while anonymous was failing.

## Notes

- The real safety net is the retry loop in kestra-io/kestra#18126, which reads `GITHUB_TOKEN`/`GH_TOKEN` when present. **That PR should merge first**; this one just makes hitting the retry path rare.
- Scoped **per step** rather than per job on purpose: the surrounding steps (`comment PR with test report`, `report-java`'s sonar) already pass their own tokens, and this keeps the blast radius to the Gradle steps.
- `composite/report-java`'s `./gradlew sonar` already exports a token, so it needed no change. `composite/publish-java` and `plugins.yml` are plugin-repo paths that never build the `:script` module.
- Verified with `actionlint` — the only findings on the touched files are pre-existing (custom `runs-on` labels, shellcheck on `run:` bodies I did not touch).