### PR TITLE
feat(publish-java): accept individual sonatype-* inputs

### DIFF
--- a/composite/publish-java/action.yml
+++ b/composite/publish-java/action.yml
@@ -6,9 +6,39 @@ inputs:
     description: 'Does we push to private maven registry'
     required: true
 
+  # Prefer the individual sonatype-* inputs below. Passing the whole `secrets` context to an action
+  # in another repository is a secret-exfiltration shape GitHub's heuristics flag, and a flagged
+  # workflow does not run until someone with write access approves it — it held kestra-io/kotlp's
+  # v0.1.1 release with zero jobs started.
   secrets:
-    description: 'Secrets passed as toJSON'
-    required: true
+    description: 'Every secret passed as toJSON. Legacy fallback, only read for keys the individual inputs below do not supply.'
+    required: false
+    default: '{}'
+
+  sonatype-user:
+    description: 'Sonatype username. Takes precedence over secrets.SONATYPE_USER.'
+    required: false
+    default: ''
+
+  sonatype-password:
+    description: 'Sonatype password. Takes precedence over secrets.SONATYPE_PASSWORD.'
+    required: false
+    default: ''
+
+  sonatype-gpg-keyid:
+    description: 'Sonatype GPG key id. Takes precedence over secrets.SONATYPE_GPG_KEYID.'
+    required: false
+    default: ''
+
+  sonatype-gpg-password:
+    description: 'Sonatype GPG password. Takes precedence over secrets.SONATYPE_GPG_PASSWORD.'
+    required: false
+    default: ''
+
+  sonatype-gpg-file:
+    description: 'Base64-encoded Sonatype GPG secret keyring. Takes precedence over secrets.SONATYPE_GPG_FILE.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -69,13 +99,20 @@ runs:
     - name: Publish - Release package to Maven Central
       if: ${{ inputs.is-private == 'false' }}
       env:
-        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ fromJson(inputs.secrets).SONATYPE_USER }}
-        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ fromJson(inputs.secrets).SONATYPE_PASSWORD }}
-        SONATYPE_GPG_KEYID: ${{ fromJson(inputs.secrets).SONATYPE_GPG_KEYID }}
-        SONATYPE_GPG_PASSWORD: ${{ fromJson(inputs.secrets).SONATYPE_GPG_PASSWORD }}
-        SONATYPE_GPG_FILE: ${{ fromJson(inputs.secrets).SONATYPE_GPG_FILE }}
+        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ inputs.sonatype-user || fromJson(inputs.secrets).SONATYPE_USER }}
+        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ inputs.sonatype-password || fromJson(inputs.secrets).SONATYPE_PASSWORD }}
+        SONATYPE_GPG_KEYID: ${{ inputs.sonatype-gpg-keyid || fromJson(inputs.secrets).SONATYPE_GPG_KEYID }}
+        SONATYPE_GPG_PASSWORD: ${{ inputs.sonatype-gpg-password || fromJson(inputs.secrets).SONATYPE_GPG_PASSWORD }}
+        SONATYPE_GPG_FILE: ${{ inputs.sonatype-gpg-file || fromJson(inputs.secrets).SONATYPE_GPG_FILE }}
       shell: bash
       run: |
+        # Neither source supplied credentials: fail here rather than let Gradle report an opaque 401.
+        if [ -z "${ORG_GRADLE_PROJECT_mavenCentralUsername}" ] || [ -z "${SONATYPE_GPG_FILE}" ]; then
+          echo "::error::No Sonatype credentials. Pass the sonatype-* inputs, or a 'secrets' JSON carrying SONATYPE_USER/SONATYPE_PASSWORD/SONATYPE_GPG_KEYID/SONATYPE_GPG_PASSWORD/SONATYPE_GPG_FILE."
+          exit 1
+        fi
+
+        mkdir -p ~/.gradle
         echo "signing.keyId=${SONATYPE_GPG_KEYID}" > ~/.gradle/gradle.properties
         echo "signing.password=${SONATYPE_GPG_PASSWORD}" >> ~/.gradle/gradle.properties
         echo "signing.secretKeyRingFile=${HOME}/.gradle/secring.gpg" >> ~/.gradle/gradle.properties


### PR DESCRIPTION
## Why

`publish-java` had one way in — the entire `secrets` context as JSON:

```yaml
with:
  secrets: ${{ toJSON(secrets) }}
```

Handing that to an action in **another repository** is a classic secret-exfiltration shape, and GitHub's heuristics flag it. A flagged workflow does not run at all:

> GitHub detected that this workflow file may be malicious. It will not run until someone with write access approves it.

That is what happened to kestra-io/kotlp's `v0.1.1` release ([run](https://github.com/kestra-io/kotlp/actions/runs/31717224312)) — zero jobs started, conclusion `action_required`, while its two earlier releases (before adopting this composite) ran unattended. The repo's Actions policy is unrestricted, so it is the heuristic, not a setting.

Composite actions can't read `secrets` themselves, which is why the blob input exists — but nothing forced it to be *all* of them.

## What

One input per credential, each taking precedence over the matching key in `secrets`:

```yaml
with:
  is-private: 'false'
  sonatype-user: ${{ secrets.SONATYPE_USER }}
  sonatype-password: ${{ secrets.SONATYPE_PASSWORD }}
  sonatype-gpg-keyid: ${{ secrets.SONATYPE_GPG_KEYID }}
  sonatype-gpg-password: ${{ secrets.SONATYPE_GPG_PASSWORD }}
  sonatype-gpg-file: ${{ secrets.SONATYPE_GPG_FILE }}
```

**Existing callers are untouched.** `secrets` stays supported, becomes `required: false` and defaults to `'{}'` — so `fromJson` is still safe when a caller passes only the new inputs, and `plugins.yml` keeps working with no change (verified: it passes `secrets:` and no `sonatype-*`, so every value falls back exactly as before).

Two things that used to be the caller's problem moved in here:

- **explicit failure** when neither source supplies credentials, instead of letting Gradle report an opaque 401;
- **`mkdir -p ~/.gradle`** — the step wrote `~/.gradle/gradle.properties` assuming an earlier step had created the directory.

## Testing

Static only — this can't be exercised without publishing something. YAML parses; the action still declares `using: composite` with its three steps intact; resolution order confirmed by reading the rendered env block:

```
ORG_GRADLE_PROJECT_mavenCentralUsername = ${{ inputs.sonatype-user || fromJson(inputs.secrets).SONATYPE_USER }}
…
```

Empty inputs are falsy in GitHub expressions, so an absent `sonatype-*` falls through to the JSON, and an absent `secrets` parses as `{}` and yields null → the guard fires.

(`actionlint` doesn't apply here — it lints workflows, not action definitions.)

## Follow-up

kestra-io/kotlp#5 switches to the individual inputs once this merges. `plugins.yml` and `report-java` still pass the whole context; worth the same treatment if plugin repos ever hit the flag, but out of scope here.