### PR TITLE
feat(composites): accept individual secret inputs instead of the whole context

### DIFF
--- a/.github/workflows/kestra-ee-backend-tests.yml
+++ b/.github/workflows/kestra-ee-backend-tests.yml
@@ -141,4 +141,8 @@ jobs:
         uses: kestra-io/actions/composite/report-java@main
         if: ${{ !cancelled() }}
         with:
-          secrets: ${{ toJSON(secrets) }}
+          # GITHUB_AUTH_TOKEN and SONAR_TOKEN are not declared in this workflow's `secrets:` block,
+          # so they were never in the context this passed on either — Sonar stays inert here.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          google-service-account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}

--- a/.github/workflows/kestra-oss-backend-tests.yml
+++ b/.github/workflows/kestra-oss-backend-tests.yml
@@ -105,4 +105,8 @@ jobs:
         uses: kestra-io/actions/composite/report-java@main
         if: ${{ !cancelled() }}
         with:
-          secrets: ${{ toJSON(secrets) }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-auth-token: ${{ secrets.GITHUB_AUTH_TOKEN }}
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          google-service-account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -312,7 +312,11 @@ jobs:
         uses: kestra-io/actions/composite/publish-java@main
         if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && startsWith(github.repository, 'kestra-io/') && steps.publish-guard.outputs.should-publish == 'true' }}
         with:
-          secrets: ${{ toJSON(secrets) }}
+          sonatype-user: ${{ secrets.SONATYPE_USER }}
+          sonatype-password: ${{ secrets.SONATYPE_PASSWORD }}
+          sonatype-gpg-keyid: ${{ secrets.SONATYPE_GPG_KEYID }}
+          sonatype-gpg-password: ${{ secrets.SONATYPE_GPG_PASSWORD }}
+          sonatype-gpg-file: ${{ secrets.SONATYPE_GPG_FILE }}
           is-private: ${{ inputs.sonatype-publish == false }}
 
       # Upload JAR for PR
@@ -320,7 +324,7 @@ jobs:
         uses: kestra-io/actions/composite/jar-upload@main
         if: ${{ inputs.generate-shadowjar == true && github.event_name == 'pull_request' && startsWith(github.repository, 'kestra-io/') }}
         with:
-          secrets: ${{ toJSON(secrets) }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Cleanup disk space to avoid "no space left on device" errors during Trivy scan
       - name: Cleanup - Free up disk space
@@ -354,7 +358,7 @@ jobs:
         if: ${{ inputs.generate-shadowjar == true && github.event_name == 'pull_request' && startsWith(github.repository, 'kestra-io/') }}
         uses: kestra-io/actions/composite/scan-trivy@main
         with:
-          secrets: ${{ toJSON(secrets) }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # GitHub Release
       - name: GitHub - Create release
@@ -369,14 +373,18 @@ jobs:
         uses: kestra-io/actions/composite/report-java@main
         if: ${{ !cancelled() && inputs.skip-test == false }}
         with:
-          secrets: ${{ toJSON(secrets) }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-auth-token: ${{ secrets.GITHUB_AUTH_TOKEN }}
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          google-service-account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
       # Unreleased commits since latest release
       - name: Unreleased Commits - Comment pull request
         uses: kestra-io/actions/composite/unreleased-commits@main
         if: ${{ github.event_name == 'pull_request' }}
         with:
-          secrets: ${{ toJSON(secrets) }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Slack on error
       - name: Slack - Notify on failure

--- a/composite/jar-upload/action.yml
+++ b/composite/jar-upload/action.yml
@@ -2,9 +2,18 @@ name: 'Upload Jar'
 description: 'This action uploads the jar as artifact and comments the download link on the pull request'
 
 inputs:
+  # Prefer github-token. Passing the whole `secrets` context to an action in another repository is
+  # a secret-exfiltration shape GitHub's heuristics flag, and a flagged workflow does not run until
+  # someone with write access approves it.
   secrets:
-    description: 'Secrets passed as toJSON'
-    required: true
+    description: 'Every secret passed as toJSON. Legacy fallback, only read for keys github-token does not supply.'
+    required: false
+    default: '{}'
+
+  github-token:
+    description: 'Token used to comment the download link. Takes precedence over secrets.GITHUB_TOKEN.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -20,7 +29,7 @@ runs:
       uses: kestra-io/actions/actions/comment-update@main
       continue-on-error: true
       with:
-        github-token: ${{ fromJson(inputs.secrets).GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token || fromJson(inputs.secrets).GITHUB_TOKEN }}
         title: "📦 Artifacts"
         fetch-artifact: 'true'
         add-summary: 'false'

--- a/composite/report-java/action.yml
+++ b/composite/report-java/action.yml
@@ -6,9 +6,38 @@ inputs:
     description: 'Run Sonar analysis'
     required: false
     default: 'true'
+  # Prefer the individual inputs below. Passing the whole `secrets` context to an action in another
+  # repository is a secret-exfiltration shape GitHub's heuristics flag, and a flagged workflow does
+  # not run until someone with write access approves it.
   secrets:
-    description: 'Secrets passed as toJSON'
-    required: true
+    description: 'Every secret passed as toJSON. Legacy fallback, only read for keys the individual inputs below do not supply.'
+    required: false
+    default: '{}'
+
+  github-token:
+    description: 'Token used to publish the test report. Takes precedence over secrets.GITHUB_TOKEN.'
+    required: false
+    default: ''
+
+  github-auth-token:
+    description: 'Token used by the Sonar analysis. Takes precedence over secrets.GITHUB_AUTH_TOKEN.'
+    required: false
+    default: ''
+
+  sonar-token:
+    description: 'Sonar token. Takes precedence over secrets.SONAR_TOKEN.'
+    required: false
+    default: ''
+
+  codecov-token:
+    description: 'Codecov token. Takes precedence over secrets.CODECOV_TOKEN.'
+    required: false
+    default: ''
+
+  google-service-account:
+    description: 'Google service account used to publish Allure reports; the report steps are skipped when empty. Takes precedence over secrets.GOOGLE_SERVICE_ACCOUNT.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -36,7 +65,7 @@ runs:
       continue-on-error: true
       if: ${{ github.event_name == 'pull_request' && startsWith(github.repository, 'kestra-io/') }}
       with:
-        github-token: ${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}
+        github-token: ${{ (inputs.github-token || fromJSON(inputs.secrets).GITHUB_TOKEN) }}
         title: "🧪 Java Unit Tests"
         template: |
           ${{ steps.test-report.outputs.summary }}
@@ -50,18 +79,18 @@ runs:
       if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ (inputs.github-token || fromJSON(inputs.secrets).GITHUB_TOKEN) }}
       run: npx --yes @kestra-io/kestra-devtools generateTestReportSummary --only-errors --ci $(pwd)
 
     # GCP
     - name: GCP - Auth with unit test account
-      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT != '' }}
+      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && (inputs.google-service-account || fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT) != '' }}
       uses: 'google-github-actions/auth@v3'
       with:
-        credentials_json: '${{ fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT }}'
+        credentials_json: '${{ (inputs.google-service-account || fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT) }}'
 
     - name: GCP - Setup Cloud SDK
-      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT != ''}}
+      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && (inputs.google-service-account || fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT) != ''}}
       uses: 'google-github-actions/setup-gcloud@v3'
 
     - name: GCP - Configure project and location
@@ -73,7 +102,7 @@ runs:
     # Allure
     - name: Allure - Generate reports
       shell: bash
-      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT != ''}}
+      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && (inputs.google-service-account || fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT) != ''}}
       continue-on-error: true
       run: |
         # Multi-module builds (kestra, kestra-ee) write allure-results per module instead of
@@ -100,7 +129,7 @@ runs:
     # Jacoco
     - name: Jacoco - Copy reports
       shell: bash
-      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT != ''}}
+      if: ${{ job.status == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && (inputs.google-service-account || fromJSON(inputs.secrets).GOOGLE_SERVICE_ACCOUNT) != ''}}
       continue-on-error: true
       run: |
         if [ -d build/reports/jacoco/testCodeCoverageReport ]; then
@@ -118,14 +147,14 @@ runs:
       if: ${{ job.status == 'success' }}
       continue-on-error: true
       with:
-        token: ${{ fromJSON(inputs.secrets).CODECOV_TOKEN }}
+        token: ${{ (inputs.codecov-token || fromJSON(inputs.secrets).CODECOV_TOKEN) }}
 
     - name: Codecov - Upload test results
       uses: codecov/test-results-action@v1
       if: ${{ job.status == 'success' }}
       continue-on-error: true
       with:
-        token: ${{ fromJSON(inputs.secrets).CODECOV_TOKEN }}
+        token: ${{ (inputs.codecov-token || fromJSON(inputs.secrets).CODECOV_TOKEN) }}
 
     # Gradle dependency
     - name: Java - Gradle dependency graph
@@ -139,8 +168,8 @@ runs:
     - name: Sonar - Analyze with Sonar
       if: ${{ job.status == 'success' && inputs.run-sonar == 'true' && env.SONAR_TOKEN != '' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') }}
       env:
-        GITHUB_TOKEN: ${{ fromJSON(inputs.secrets).GITHUB_AUTH_TOKEN }}
-        SONAR_TOKEN: ${{ fromJSON(inputs.secrets).SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ (inputs.github-auth-token || fromJSON(inputs.secrets).GITHUB_AUTH_TOKEN) }}
+        SONAR_TOKEN: ${{ (inputs.sonar-token || fromJSON(inputs.secrets).SONAR_TOKEN) }}
       shell: bash
       continue-on-error: true
       run: ./gradlew sonar

--- a/composite/scan-trivy/action.yml
+++ b/composite/scan-trivy/action.yml
@@ -12,9 +12,18 @@ inputs:
     required: false
     default: "*/build/libs/*.jar"
 
+  # Prefer github-token. Passing the whole `secrets` context to an action in another repository is
+  # a secret-exfiltration shape GitHub's heuristics flag, and a flagged workflow does not run until
+  # someone with write access approves it.
   secrets:
-    description: 'Secrets passed as toJSON'
-    required: true
+    description: 'Every secret passed as toJSON. Legacy fallback, only read for keys github-token does not supply.'
+    required: false
+    default: '{}'
+
+  github-token:
+    description: 'Token used to comment the scan result. Takes precedence over secrets.GITHUB_TOKEN.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -47,7 +56,7 @@ runs:
       uses: kestra-io/actions/actions/comment-update@main
       continue-on-error: true
       with:
-        github-token: ${{ fromJSON(inputs.secrets).GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token || fromJSON(inputs.secrets).GITHUB_TOKEN }}
         title: "🛡 Trivy"
         files: |
           ${{ github.workspace }}/trivy-result.json

--- a/composite/unreleased-commits/action.yaml
+++ b/composite/unreleased-commits/action.yaml
@@ -2,9 +2,18 @@ name: 'Unreleased Commits'
 description: 'Comment unreleased commits since latest tag'
 
 inputs:
+  # Prefer github-token. Passing the whole `secrets` context to an action in another repository is
+  # a secret-exfiltration shape GitHub's heuristics flag, and a flagged workflow does not run until
+  # someone with write access approves it.
   secrets:
-    description: 'Secrets passed as toJSON'
-    required: true
+    description: 'Every secret passed as toJSON. Legacy fallback, only read for keys github-token does not supply.'
+    required: false
+    default: '{}'
+
+  github-token:
+    description: 'Token used to comment the unreleased commits. Takes precedence over secrets.GITHUB_TOKEN.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -13,7 +22,7 @@ runs:
       uses: kestra-io/actions/actions/comment-update@main
       continue-on-error: true
       with:
-        github-token: ${{ fromJson(inputs.secrets).GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token || fromJson(inputs.secrets).GITHUB_TOKEN }}
         title: "🔁 Unreleased Commits"
         fetch-unreleased-commits: true
         template: |


### PR DESCRIPTION
Follow-up to #196, which did this for `publish-java` after GitHub's heuristics held a kotlp release run ([evidence](https://github.com/kestra-io/kotlp/actions/runs/31717224312) — zero jobs, `action_required`, *"GitHub detected that this workflow file may be malicious"*). The same `secrets: ${{ toJSON(secrets) }}` pattern was still in four other composites.

## What

| composite | new inputs |
|---|---|
| `report-java` | `github-token`, `github-auth-token`, `sonar-token`, `codecov-token`, `google-service-account` |
| `jar-upload` | `github-token` |
| `scan-trivy` | `github-token` |
| `unreleased-commits` | `github-token` |

Each takes precedence over the matching key in `secrets`, which becomes `required: false` with default `'{}'` — so any caller still passing the blob keeps working, and `fromJSON` stays safe when only the new inputs are given. The seven call sites in this repo now pass individual inputs.

## Two things worth reviewing

**`kestra-ee-backend-tests` passes only three of report-java's five.** Its own `workflow_call.secrets` block declares `CODECOV_TOKEN`, `GCP_SERVICE_ACCOUNT`, `GOOGLE_SERVICE_ACCOUNT`, `OTLP_*`, `SLACK_WEBHOOK_URL` — no `GITHUB_AUTH_TOKEN`, no `SONAR_TOKEN`. So they were never in the context it forwarded either, and **Sonar has been inert in EE backend tests**; `toJSON(secrets)` hid that. Naming them explicitly is a reference to undeclared secrets, which `actionlint` rejects — so they're omitted rather than invented. Wiring Sonar up for EE is a separate decision.

**`plugins.yml` keeps one `toJSON(secrets)`** — for `oNaiPs/secrets-to-env-action@v1`, whose entire purpose is exporting every secret as an env var for plugin integration tests. It cannot be narrowed without changing what it does. It is also the most exposed of the lot: a third-party action, outside kestra-io, receiving every secret. Worth a separate look at pinning it to a SHA or replacing it.

## Testing

Static — this can't be exercised without running plugin CI. `actionlint` clean on all three changed workflows (it caught the EE undeclared-secret issue above). Every touched composite parses and still declares `using: composite`; `secrets` confirmed optional with a `'{}'` default in all five.

The risk to watch on merge is a typo in a key name silently emptying a token — the values are the same ones each composite already read, and the fallback chain means a wrong input name falls back to `secrets`, which is empty for callers that stopped passing it.