### PR TITLE
feat(ci): publish release-candidate tags to Maven

### DIFF
--- a/.github/workflows/kestra-ee-publish-maven.yml
+++ b/.github/workflows/kestra-ee-publish-maven.yml
@@ -26,8 +26,6 @@ jobs:
   maven:
     name: Publish - Maven
     runs-on: kestra-private-large
-    # skip RCs
-    if: ${{ !contains(github.ref, '-rc') }}
     env:
       COREPACK_INTEGRITY_KEYS: 0
     steps:

--- a/.github/workflows/kestra-oss-publish-maven.yml
+++ b/.github/workflows/kestra-oss-publish-maven.yml
@@ -38,8 +38,6 @@ jobs:
   publish:
     name: Publish - Maven
     runs-on: ubuntu-latest
-    # skip RCs
-    if: ${{ !contains(github.ref, '-rc') }}
     steps:
       - name: Checkout - Current ref
         uses: actions/checkout@v5


### PR DESCRIPTION
## What

Deletes the `-rc` skip (`if: ${{ !contains(github.ref, '-rc') }}`) from the two reusable Maven publish workflows:

- `kestra-oss-publish-maven.yml`
- `kestra-ee-publish-maven.yml`

so `vX.Y.Z-rcN` tags are published to Maven Central (OSS) / the private Maven registry (EE) exactly like regular releases — same test gating, same signing/staging (an `-rcN` version is a valid non-SNAPSHOT release version for the publish plugins).

## Why deletion is safe (no caller changes needed)

Org-wide code search shows exactly four callers of these workflows:

- `kestra-io/kestra` + `kestra-io/kestra-ee` `main-build.yml` — Maven publish job gated on `github.ref == 'refs/heads/develop'`, a ref that can never contain `-rc` → unaffected.
- `kestra-io/kestra` + `kestra-io/kestra-ee` `pre-release.yml` — the tag path, the only source of `-rc` refs, and exactly where RC publishing is now wanted.

With the new policy the guard protected nothing, so it's removed rather than made configurable.

## What stays skipped for RCs (unchanged, guarded elsewhere)

GitHub release + release-note merge, configuration schema publish, helm release, Docker minor/latest/lts retags, and the EE after-release webhook all keep their own `-rc` guards.

## Note

Maven Central is immutable: a published RC stays forever and appears in `maven-metadata.xml` (dynamic-version consumers may resolve it). This is the intended trade-off.