### PR TITLE
fix(helm): checkout the release ref, and remove the unused standalone dispatch trigger

### DIFF
--- a/.github/workflows/kestra-oss-helm-release.yml
+++ b/.github/workflows/kestra-oss-helm-release.yml
@@ -1,24 +1,8 @@
 name: Publish Helm charts (OSS)
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Kestra version to release (e.g. 1.3.22, without v prefix)'
-        required: true
-        type: string
-      dry-run:
-        description: 'Dry run — package charts but do not upload to GCS'
-        required: true
-        type: boolean
-        default: true
   workflow_call:
     inputs:
-      version:
-        description: 'Kestra version to release (e.g. 1.3.22, without v prefix). If omitted, inferred from GITHUB_REF_NAME.'
-        required: false
-        type: string
-        default: ''
       dry-run:
         description: 'Dry run — package charts but do not upload to GCS'
         required: false
@@ -45,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: kestra-io/kestra
-          ref: ${{ github.event_name == 'workflow_dispatch' && 'develop' || github.ref }}
+          ref: ${{ github.ref }}
 
       - name: Setup Helm
         uses: azure/setup-helm@v5
@@ -71,13 +55,8 @@ jobs:
       - name: Resolve version and dry-run flag
         id: config
         run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
-            TAG="v${VERSION}"
-          else
-            TAG="${GITHUB_REF_NAME}"
-            VERSION="${TAG#v}"
-          fi
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
           DRY_RUN="${{ inputs.dry-run }}"
           echo "tag=${TAG}"        >> $GITHUB_OUTPUT
           echo "version=${VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
\`github.event_name\` reflects the top-level caller's triggering event throughout a \`workflow_call\` chain. Since \`kestra-io/kestra\`'s \`release-docker.yml\` (the only real caller of this reusable workflow) only ever triggers via \`workflow_dispatch\`, the checkout-ref ternary's \`|| github.ref\` branch was unreachable in practice — every chart release packaged \`develop\`'s current \`charts/\` tree regardless of which version was nominally being released, or which ref the operator actually selected when dispatching. This let a Kestra-2.0-only chart change (removing \`--worker-group\`, kestra-io/kestra#17643) leak into published 1.3.x charts \`1.3.30\`-\`1.3.33\`.

The Helm chart is always released together with the Kestra image, as part of the same process — it's never triggered on its own. So the standalone \`workflow_dispatch\` trigger this workflow also had was dead surface area rather than a real entry point. Removing it leaves \`workflow_call\` as the only way in, which makes \`github.ref\` (inherited from the caller's run context) unconditionally correct — no conditional logic needed.

That also made the \`workflow_call\` \`version\` input dead (it only existed for the now-removed dispatch trigger), so it's removed too, along with the branch in "Resolve version and dry-run flag" that consumed it — the tag is always derived from \`GITHUB_REF_NAME\`.

Does not change how or when any release is triggered — that stays entirely as-is, owned by release engineering.